### PR TITLE
Additional fonts in the docs body

### DIFF
--- a/docs/css/docs.css
+++ b/docs/css/docs.css
@@ -20,7 +20,7 @@
 
 body {
   position: relative; /* For scrollspy */
-  font-family: 'PT Serif', serif;
+  font-family: 'PT Serif', Cambria, Georgia, serif;
 }
 
 .devtools img {


### PR DESCRIPTION
The default font used in docs is PT Serif, which I doubt many people have installed on their machine, so I'd added some alternatives in the CSS (Cambria and Georgia, 1st is from Win 7> I believe, the other is available on other systems I think). Otherwise the default serif font is used and that's Times New Roman for most people, which doesn't look good here IMO. I know, a minor thing, but will help me thinks ;)

PT Serif could be used as web font using for example Google Fonts, but there are many cons to that solution.