### PR TITLE
Adding http prefixes on docuentation href links

### DIFF
--- a/guides/getting-started/index.html
+++ b/guides/getting-started/index.html
@@ -586,7 +586,7 @@ open http://localhost:5000</code></pre></div>
 <div class="highlight"><pre><code class="language-bash" data-lang="bash">npm install --save marty
 bower install --save marty</code></pre></div>
 
-<p>Marty is built using <a href="https://github.com/umdjs/umd">UMD</a>. This means you can use it from <a href="nodejs.org">node.js</a> or <a href="browserify.org">Browserify</a></p>
+<p>Marty is built using <a href="https://github.com/umdjs/umd">UMD</a>. This means you can use it from <a href="http://nodejs.org">node.js</a> or <a href="http://browserify.org">Browserify</a></p>
 
 <div class="highlight"><pre><code class="language-js" data-lang="js"><span class="kd">var</span> <span class="nx">Marty</span> <span class="o">=</span> <span class="nx">require</span><span class="p">(</span><span class="s1">'marty'</span><span class="p">);</span>
 
@@ -594,7 +594,7 @@ bower install --save marty</code></pre></div>
   <span class="p">...</span>
 <span class="p">})</span></code></pre></div>
 
-<p>Or <a href="requirejs.org">require.js</a> (<a href="https://github.com/jhollingworth/marty/tree/master/examples/requirejs">Working example</a>)</p>
+<p>Or <a href="http://requirejs.org">require.js</a> (<a href="https://github.com/jhollingworth/marty/tree/master/examples/requirejs">Working example</a>)</p>
 
 <div class="highlight"><pre><code class="language-js" data-lang="js"><span class="nx">require</span><span class="p">([</span><span class="s1">'marty'</span><span class="p">],</span> <span class="kd">function</span> <span class="p">(</span><span class="nx">Marty</span><span class="p">)</span> <span class="p">{</span>
   <span class="k">return</span> <span class="nx">Marty</span><span class="p">.</span><span class="nx">createStore</span><span class="p">({</span>


### PR DESCRIPTION
Some links to external sites were missing http prefixes, making them point to non-existent urls.