### PR TITLE
Fix for `isJson` when no "Content-Type" header

### DIFF
--- a/lib/stateSources/http.js
+++ b/lib/stateSources/http.js
@@ -43,7 +43,13 @@ function HttpStateSource(mixinOptions) {
       function isJson(res) {
         var contentTypes = getHeader(res, CONTENT_TYPE);
 
-        _.isArray(contentTypes) || (contentTypes = [contentTypes]);
+        if (!_.isArray(contentTypes)) {
+          if (contentTypes === undefined || contentTypes === null) {
+            contentTypes = [];
+          } else {
+            contentTypes = [contentTypes];
+          }
+        }
 
         return _.any(contentTypes, function (contentType) {
           return contentType.indexOf(JSON_CONTENT_TYPE) !== -1;


### PR DESCRIPTION
Related issue: https://github.com/jhollingworth/marty/issues/99