### PR TITLE
Avoiding direct calls to console functions for IE8 happiness.

### DIFF
--- a/lib/diagnostics.js
+++ b/lib/diagnostics.js
@@ -10,12 +10,12 @@ module.exports = diagnostics;
 
 function log() {
   if (diagnostics.enabled) {
-    console.log.apply(console, arguments);
+    console && console.log.apply(console, arguments);
   }
 }
 
 function warn() {
   if (diagnostics.enabled) {
-    console.warn.apply(console, arguments);
+    console && console.warn.apply(console, arguments);
   }
 }

--- a/lib/store.js
+++ b/lib/store.js
@@ -76,7 +76,7 @@ function Store(options) {
           functionName += ' in ' + options.displayName;
         }
 
-        console.warn(functionName + ' is reserved for use by Marty. Please use a different name');
+        Diagnostics.warn(functionName + ' is reserved for use by Marty. Please use a different name');
       }
     });
 
@@ -242,7 +242,7 @@ function Store(options) {
           }
         }
 
-        console.warn(promiseNotReturnedWarning());
+        Diagnostics.warn(promiseNotReturnedWarning());
 
         return notFound();
       } catch (error) {


### PR DESCRIPTION
Making sure we always go through the Diagnostics object. Also added an extra check there that console exists, just in case someone on IE8 sets enabled to true.