### PR TITLE
:memo: Change constants variable name from UserActions to UserConstants ...

### DIFF
--- a/docs/_guides/action-creators/source-action-creators.md
+++ b/docs/_guides/action-creators/source-action-creators.md
@@ -12,14 +12,14 @@ The way to get around this is to have a seperate action creator that is responsi
 {% highlight js %}
 // actions/userActionCreators.js
 var UserActionCreators = Marty.createActionCreators({
-  saveUser: UserActions.SAVE_USER(function (user) {
+  saveUser: UserConstants.SAVE_USER(function (user) {
     return UserAPI.saveUser(user);
   })
 });
 
 // actions/userSourceActionCreators.js
 var UserSourceActionCreators = Marty.createActionCreators({
-  addUser: UserActions.ADD_USER(function (user) {
+  addUser: UserConstants.ADD_USER(function (user) {
     this.dispatch(user);
   })
 });


### PR DESCRIPTION
...to prevent confusion and to match other examples

UserActions makes it look like it could refer to action creators instead of constants.

See https://github.com/jhollingworth/marty-chat-example/blob/master/app/actions/roomActionCreators.js for an example of how the constants variable is named elsewhere.