### PR TITLE
Use res.headers.get for isJson

### DIFF
--- a/lib/stateSources/http.js
+++ b/lib/stateSources/http.js
@@ -41,25 +41,7 @@ function HttpStateSource(mixinOptions) {
       });
 
       function isJson(res) {
-        var contentTypes = getHeader(res, CONTENT_TYPE);
-
-        if (!_.isArray(contentTypes)) {
-          if (contentTypes === undefined || contentTypes === null) {
-            contentTypes = [];
-          } else {
-            contentTypes = [contentTypes];
-          }
-        }
-
-        return _.any(contentTypes, function (contentType) {
-          return contentType.indexOf(JSON_CONTENT_TYPE) !== -1;
-        });
-      }
-
-      function getHeader(res, name) {
-        return _.find(res.headers.map, function (value, key) {
-          return key.toLowerCase() === name.toLowerCase();
-        });
+        return res.headers.get(CONTENT_TYPE) === JSON_CONTENT_TYPE;
       }
 
       function contentType() {


### PR DESCRIPTION
I just started trying to use Marty and my responses for a JSON request weren't coming back with a body. I tracked it down to `res.headers.map` being undefined. I'm not sure where `res.headers.map` coming from, but I certainly can't find it in the [isomorphic fetch](https://github.com/matthew-andrews/node-fetch/blob/master/lib/headers.js) library that Marty uses. Meanwhile, that fetch library does have a simple `get` method on headers.

Am I missing something here or is this a bug? It did fix my application.