### PR TITLE
Use a fake JSON endpoint for the examples

### DIFF
--- a/docs/_guides/stores/fetching-data.md
+++ b/docs/_guides/stores/fetching-data.md
@@ -36,7 +36,7 @@ Using the example of getting a user, you would have a UserHttpAPI (Which is an [
 {% highlight js %}
 var UserHttpAPI = Marty.createStateSource({
   getUser: function (userId) {
-    return this.get('/users/' + userId).then(function (res) {
+    return this.get('http://jsonplaceholder.typicode.com/users/' + userId).then(function (res) {
       UserSourceActionCreators.receiveUser(res.body);
     });
   }


### PR DESCRIPTION
Set a fake JSON endpoint that would actually return something. [json placeholder](http://jsonplaceholder.typicode.com/) seems to work well for this. There are a good few use cases to test it with. :)