### PR TITLE
Improve error logging

### DIFF
--- a/lib/actionCreators.js
+++ b/lib/actionCreators.js
@@ -1,11 +1,11 @@
 var _ = require('underscore');
+var log = require('./logger');
 var uuid = require('./utils/uuid');
 var RESERVED_KEYWORDS = ['dispatch'];
 var Dispatcher = require('./dispatcher');
 var ActionPayload = require('./actionPayload');
 var ActionConstants = require('../constants/actions');
 var serializeError = require('./utils/serializeError');
-
 
 function ActionCreators(options) {
   var creator = this;
@@ -18,7 +18,6 @@ function ActionCreators(options) {
       throw new Error(keyword + ' is a reserved keyword');
     }
   });
-
 
   this.getActionType = getActionType;
 
@@ -77,6 +76,10 @@ function ActionCreators(options) {
 
           return result;
         } catch (e) {
+          var error = 'An error occured when creating a \'' + actionType + '\' action in ';
+          error += (creator.displayName || creator.id || ' ') + '#' + name;
+          log.error(error, e);
+
           dispatchFailed(e);
 
           throw e;

--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -8,36 +8,43 @@ module.exports = {
   notFound: notFound
 };
 
-function pending() {
+function pending(id, store) {
   return fetchResult({
+    id: id,
     pending: true,
     status: 'PENDING'
-  });
+  }, store);
 }
 
-function failed(error) {
+function failed(error, id, store) {
   return fetchResult({
+    id: id,
     error: error,
     failed: true,
     status: 'FAILED'
-  });
+  }, store);
 }
 
-function done(result) {
+function done(result, id, store) {
   return fetchResult({
+    id: id,
     done: true,
     status: 'DONE',
     result: result
-  });
+  }, store);
 }
 
-function notFound() {
-  return failed(new NotFoundError());
+function notFound(id, store) {
+  return failed(new NotFoundError(), id, store);
 }
 
-function fetchResult(result) {
+function fetchResult(result, store) {
   result.when = when;
   result._isFetchResult = true;
+
+  if (store) {
+    result.store = store.displayName || store.id;
+  }
 
   return result;
 }

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,0 +1,11 @@
+var _ = require('underscore');
+
+if (console) {
+  module.exports = console;
+} else {
+  module.exports = {
+    log: _.noop,
+    warn: _.noop,
+    error: _.noop
+  };
+}

--- a/lib/mixins/stateMixin.js
+++ b/lib/mixins/stateMixin.js
@@ -1,4 +1,5 @@
 var _ = require('underscore');
+var log = require('../logger');
 var uuid = require('../utils/uuid');
 var Diagnostics = require('../diagnostics');
 var reservedKeys = ['listenTo', 'getState', 'getInitialState'];
@@ -24,7 +25,7 @@ function StateMixin(options) {
       );
 
       if (this._lifeCycleState === 'UNMOUNTED') {
-        Diagnostics.warn(
+        log.warn(
           'Trying to set the state of ', this.displayName, 'component (' + this._marty.id + ') which is unmounted'
         );
       } else {
@@ -41,6 +42,10 @@ function StateMixin(options) {
       try {
         return this.getState();
       } catch (e) {
+        var errorMessage = 'An error occured while trying to get the latest state in the view ' + this.displayName;
+
+        log.error(errorMessage, e, this);
+
         if (handler) {
           handler.failed(e);
         }

--- a/lib/store.js
+++ b/lib/store.js
@@ -1,5 +1,6 @@
 var CHANGE_EVENT = 'changed';
 var _ = require('underscore');
+var log = require('./logger');
 var uuid = require('./utils/uuid');
 var fetchResult = require('./fetch');
 var Dispatcher = require('./dispatcher');
@@ -176,12 +177,12 @@ function Store(options) {
       error = failedFetches[options.id];
 
       if (error) {
-        return fetchResult.failed(error);
+        return fetchResult.failed(error, options.id, store);
       }
     }
 
     if (fetchInProgress[options.id]) {
-      return fetchResult.pending();
+      return fetchResult.pending(options.id, store);
     }
 
     return tryAndGetLocally() || tryAndGetRemotely();
@@ -199,11 +200,11 @@ function Store(options) {
         }
 
         finished();
-        return fetchResult.done(result);
+        return fetchResult.done(result, options.id, store);
       } catch (error) {
         failed(error);
 
-        return fetchResult.failed(error);
+        return fetchResult.failed(error, options.id, store);
       }
     }
 
@@ -231,7 +232,7 @@ function Store(options) {
               hasChanged();
             });
 
-            return fetchResult.pending();
+            return fetchResult.pending(options.id, store);
           } else {
             fetchHistory[options.id] = true;
             result = tryAndGetLocally();
@@ -274,11 +275,11 @@ function Store(options) {
 
       finished();
 
-      return fetchResult.failed(error);
+      return fetchResult.failed(error, options.id, store);
     }
 
     function notFound() {
-      return failed(new NotFoundError());
+      return failed(new NotFoundError(), options.id, store);
     }
   }
 
@@ -301,11 +302,11 @@ function Store(options) {
         }
 
         if (dependencyErrors.length) {
-          return fetchResult.failed(new CompoundError(dependencyErrors));
+          return fetchResult.failed(new CompoundError(dependencyErrors), options.id, store);
         }
 
         if (pending) {
-          return fetchResult.pending();
+          return fetchResult.pending(options.id, store);
         }
       } else {
         if (!options.dependsOn.done) {
@@ -375,6 +376,17 @@ function Store(options) {
               throw new ActionHandlerNotFoundError(handlerName, this);
             }
           } catch (e) {
+            var errorMessage = 'An error occured while trying to handle an \'' +
+            action.type.toString() + '\' action in the action handler `' + handlerName + '`';
+
+            var displayName = store.displayName || store.id;
+
+            if (displayName) {
+              errorMessage += ' within the store ' + displayName;
+            }
+
+            log.error(errorMessage, e, action);
+
             handler.failed(e);
             throw e;
           } finally {

--- a/lib/when.js
+++ b/lib/when.js
@@ -1,4 +1,5 @@
 var _ = require('underscore');
+var log = require('./logger');
 var StatusConstants = require('../constants/status');
 
 when.all = all;
@@ -13,15 +14,33 @@ function when(handlers) {
     throw new Error('Could not find a ' + this.status + ' handler');
   }
 
-  switch (this.status) {
-    case StatusConstants.PENDING.toString():
-      return handler.call(handlers);
-    case StatusConstants.FAILED.toString():
-      return handler.call(handlers, this.error);
-    case StatusConstants.DONE.toString():
-      return handler.call(handlers, this.result);
-    default:
-      throw new Error('Unknown fetch result status');
+  try {
+    switch (this.status) {
+      case StatusConstants.PENDING.toString():
+        return handler.call(handlers);
+      case StatusConstants.FAILED.toString():
+        return handler.call(handlers, this.error);
+      case StatusConstants.DONE.toString():
+        return handler.call(handlers, this.result);
+      default:
+        throw new Error('Unknown fetch result status');
+    }
+  } catch (e) {
+    var errorMessage = 'An error occured when handling the DONE state of ';
+
+    if (this.id) {
+      errorMessage += 'the fetch \'' + this.id + '\'';
+    } else {
+      errorMessage += 'a fetch';
+    }
+
+    if (this.store) {
+      errorMessage += ' from the store ' + this.store;
+    }
+
+    log.error(errorMessage, e);
+
+    throw e;
   }
 }
 

--- a/logger.js
+++ b/logger.js
@@ -1,0 +1,1 @@
+module.exports = require('./lib/logger');

--- a/test/actionCreatorsSpec.js
+++ b/test/actionCreatorsSpec.js
@@ -5,6 +5,7 @@ var Store = require('../lib/store');
 var constants = require('../lib/constants');
 var Dispatcher = require('flux').Dispatcher;
 var Promise = require('es6-promise').Promise;
+var stubbedLogger = require('./lib/stubbedLogger');
 var MockDispatcher = require('./lib/mockDispatcher');
 var ActionCreators = require('../lib/actionCreators');
 var serializeError = require('../lib/utils/serializeError');
@@ -12,10 +13,15 @@ var serializeError = require('../lib/utils/serializeError');
 describe('ActionCreators', function () {
   var actionCreators, dispatcher, actualResult, actualError;
   var expectedActionType, expectedOtherArg, expectedArg;
-  var actualAction, payload, expectedError, promise;
+  var actualAction, payload, expectedError, promise, logger;
 
   beforeEach(function () {
+    logger = stubbedLogger();
     dispatcher = new MockDispatcher();
+  });
+
+  afterEach(function () {
+    logger.restore();
   });
 
   describe('when you create an action creator called \'dispatch\'', function () {
@@ -162,6 +168,7 @@ describe('ActionCreators', function () {
     beforeEach(function () {
       expectedError = new Error('foo');
       actionCreators = new ActionCreators({
+        displayName: 'Test',
         dispatcher: dispatcher,
         someAction: function () {
           throw expectedError;
@@ -175,6 +182,12 @@ describe('ActionCreators', function () {
 
       actualAction = dispatcher.getActionWithType('ACTION_FAILED');
       payload = (actualAction || {}).arguments[0];
+    });
+
+    it('should log the error', function () {
+      var expectedErrorMessage = 'An error occured when creating a \'SOME_ACTION\' action in Test#someAction';
+
+      expect(logger.error).to.be.calledWith(expectedErrorMessage, expectedError);
     });
 
     it('should dispatch {action type}_FAILED', function () {

--- a/test/aliasesSpec.js
+++ b/test/aliasesSpec.js
@@ -31,6 +31,12 @@ describe('aliases', function () {
     });
   });
 
+  describe('marty/logger', function () {
+    it('should resolve to logger', function () {
+      expect(require('../logger')).to.equal(require('../lib/logger'));
+    });
+  });
+
   describe('marty/actionPayload', function () {
     it('should resolve to actionPayload', function () {
       expect(require('../actionPayload')).to.equal(require('../lib/actionPayload'));

--- a/test/lib/stubbedLogger.js
+++ b/test/lib/stubbedLogger.js
@@ -1,0 +1,19 @@
+var sinon = require('sinon');
+var _ = require('underscore');
+var logger = require('../../logger');
+
+function stubbedLogger() {
+  var sandbox = sinon.sandbox.create();
+
+  _.each(logger, function (func, key) {
+    sandbox.stub(logger, key);
+  });
+
+  return _.extend({
+    restore: function () {
+      sandbox.restore();
+    }
+  }, logger);
+}
+
+module.exports = stubbedLogger;

--- a/test/stateMixinSpec.js
+++ b/test/stateMixinSpec.js
@@ -4,14 +4,16 @@ var Marty = require('../index');
 var expect = require('chai').expect;
 var uuid = require('../lib/utils/uuid');
 var Diagnostics = require('../lib/diagnostics');
+var stubbedLogger = require('./lib/stubbedLogger');
 var ActionPayload = require('../lib/actionPayload');
 var StateMixin = require('../lib/mixins/stateMixin');
 var TestUtils = require('react/addons').addons.TestUtils;
 
 describe('StateMixin', function () {
-  var element, sandbox, mixin, initialState;
+  var element, sandbox, mixin, initialState, logger;
 
   beforeEach(function () {
+    logger = stubbedLogger();
     sandbox = sinon.sandbox.create();
     initialState = {
       name: 'hello'
@@ -27,11 +29,36 @@ describe('StateMixin', function () {
 
   afterEach(function () {
     Diagnostics.devtoolsEnabled = false;
+    logger.restore();
     sandbox.restore();
   });
 
   it('should throw an error if you dont pass in an object literal', function () {
     expect(function () { StateMixin(); }).to.throw(Error);
+  });
+
+  describe('when an error is thrown when getting state', function () {
+    var expectedError;
+
+    beforeEach(function () {
+      expectedError = new Error('Bar');
+      mixin = new StateMixin({
+        displayName: 'Test',
+        getState: function () {
+          throw expectedError;
+        }
+      });
+
+      try {
+        mixin.tryGetState();
+      } catch (e) { }
+    });
+
+    it('should log the error and any additional metadata', function () {
+      var expectedMessage = 'An error occured while trying to get the latest state in the view Test';
+
+      expect(logger.error).to.be.calledWith(expectedMessage, expectedError, mixin);
+    });
   });
 
   describe('when a store changes', function () {

--- a/test/storeFetchTest.js
+++ b/test/storeFetchTest.js
@@ -12,6 +12,7 @@ describe('Store#fetch()', function () {
     fetchId = 'foo';
     listener = sinon.spy();
     store = Marty.createStore({
+      displayName: 'Test',
       getInitialState: _.noop
     });
     changeListener = store.addChangeListener(listener);
@@ -356,7 +357,7 @@ describe('Store#fetch()', function () {
     });
 
     it('should return a fetch not found result', function () {
-      expect(actualResult).to.eql(store.fetch.notFound());
+      expect(actualResult).to.eql(store.fetch.notFound('bar', store));
     });
 
     it('should not call remotely', function () {

--- a/test/whenSpec.js
+++ b/test/whenSpec.js
@@ -1,12 +1,15 @@
+var util = require('util');
 var sinon = require('sinon');
 var when = require('../when');
 var fetch = require('../fetch');
 var expect = require('chai').expect;
+var stubbedLogger = require('./lib/stubbedLogger');
 
 describe('when', function () {
-  var handlers, expectedResult1, expectedResult2, expectedError;
+  var handlers, logger, expectedResult1, expectedResult2, expectedError;
 
   beforeEach(function () {
+    logger = stubbedLogger();
     expectedError = new Error();
     expectedResult1 = { foo: 'bar' };
     expectedResult2 = { baz: 'bam' };
@@ -15,6 +18,42 @@ describe('when', function () {
       failed: sinon.stub(),
       done: sinon.stub()
     };
+  });
+
+  afterEach(function () {
+    logger.restore();
+  });
+
+  describe('when an error occurs in a when handler', function () {
+    var expectedError, expectedFetchId, expectedStore;
+
+    beforeEach(function () {
+      expectedStore = 'Foo';
+      expectedFetchId = '123';
+      expectedError = new Error('bar');
+
+      var doneFetch = fetch.done({}, expectedFetchId, {
+        displayName: expectedStore
+      });
+
+      try {
+        doneFetch.when({
+          done: function () {
+            throw expectedError;
+          }
+        });
+      } catch (e) { }
+    });
+
+    it('should log the error and any additional metadata', function () {
+      var expectedMessage = util.format(
+        'An error occured when handling the DONE state of the fetch \'%s\' from the store %s',
+        expectedFetchId,
+        expectedStore
+      );
+
+      expect(logger.error).to.be.calledWith(expectedMessage, expectedError);
+    });
   });
 
   describe('#all()', function () {


### PR DESCRIPTION
People have been finding it hard to diagnose where errors come from
because the promises would swallow them. I've added some logging around
places where Marty calls into user code, namely:

- `Store#handleAction`: We log the store, action handler, error and action
- `StateMixin#getState`: We log the view and error
- `when`: We log the fetch, store and error
- `ActionCreator`: We log the action type, action, action creator and error

Resolves #127