### PR TITLE
Replaced reactify for babelify as Babel now supports JSX transforms

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,9 @@
+unreleased
+==================
+
+- Replaced `reactify` for `babelify` as Babel now supports JSX transforms too and will help
+with an ES6 transition.
+
 0.8.12 / 2015-02-14
 ===================
 - Added improved error logging [#129](https://github.com/jhollingworth/marty/issues/129)

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -98,7 +98,7 @@ module.exports = function (config) {
       basePath: '',
       frameworks: ['mocha', 'browserify'],
       browserify: {
-        transform: ['reactify'],
+        transform: ['babelify'],
         debug: true
       },
       files: [

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "flux"
   ],
   "devDependencies": {
+    "babelify": "^5.0.3",
     "bluebird": "^2.3.11",
     "body-parser": "^1.9.3",
     "browserify": "^5.12.0",
@@ -42,7 +43,6 @@
     "mocha": "^1.21.4",
     "mocha-spec-cov": "0.0.3",
     "react": "^0.12.0",
-    "reactify": "^0.14.0",
     "sinon": "^1.10.3",
     "sinon-chai": "^2.5.0",
     "uglify-js": "^2.4.15",
@@ -62,7 +62,7 @@
   },
   "browserify": {
     "transform": [
-      "reactify"
+      "babelify"
     ]
   },
   "homepage": "https://martyjs.org",


### PR DESCRIPTION
Replaced `reactify` for `babelify` as Babel now supports JSX transforms too and will help with an ES6 transition.