### PR TITLE
Don't auto set content-type if using FormData

### DIFF
--- a/lib/stateSources/http.js
+++ b/lib/stateSources/http.js
@@ -19,7 +19,8 @@ function HttpStateSource(mixinOptions) {
         options.headers = {};
       }
 
-      if (contentType() === JSON_CONTENT_TYPE && _.isObject(options.body)) {
+      var usingFormData = options.body instanceof FormData;
+      if (!usingFormData && contentType() === JSON_CONTENT_TYPE && _.isObject(options.body)) {
         options.body = JSON.stringify(options.body);
         options.headers[CONTENT_TYPE] = JSON_CONTENT_TYPE;
       }

--- a/test/stateSources/httpStateSourceSpec.js
+++ b/test/stateSources/httpStateSourceSpec.js
@@ -164,6 +164,50 @@ describe('HttpStateSource', function () {
         });
       });
     });
+
+    describe('when request body is a FormData object', function () {
+      var options;
+
+      beforeEach(function () {
+        API = HttpStateSource({
+          baseUrl: baseUrl.substring(0, baseUrl.length - 1)
+        });
+
+        options = {
+          url: 'foos',
+          headers: {},
+          body: new FormData()
+        };
+
+        return API.post(options);
+      });
+
+      it('should not set the Content-Type request header', function () {
+        expect(options.headers['Content-Type']).to.eql(undefined);
+      });
+    });
+
+    describe('when request body is not a FormData object', function () {
+      var options;
+
+      beforeEach(function () {
+        API = HttpStateSource({
+          baseUrl: baseUrl.substring(0, baseUrl.length - 1)
+        });
+
+        options = {
+          url: 'foos',
+          headers: {},
+          body: {}
+        };
+
+        return API.post(options);
+      });
+
+      it('should default the Content-Type request header to application/json', function () {
+        expect(options.headers['Content-Type']).to.eql('application/json');
+      });
+    });
   });
 
   describe('#delete()', function () {


### PR DESCRIPTION
When the request body is a FormData object, Fetch automatically assigns the Content-Type header to "multipart/form-data; boundary={UNIQUE BOUNDARY TOKEN}". If Content-Type is already set, Fetch will not overwrite it. Thus, to support the multipart/form-data content-type, Marty should not automatically set the Content-Type to "application/json" when the request body is a FormData object.