### PR TITLE
removed superagent from bower dependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,7 +20,6 @@
     "tests"
   ],
   "dependencies": {
-    "superagent": "~0.20.0",
     "lodash": "~2.4.1"
   }
 }


### PR DESCRIPTION
Superagent seems to be unused. I found no references to it in any of the source, and it isn't even listed in package.json.