### PR TITLE
Set react's peerDendency to work with the RC

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "marty",
-  "version": "0.0.9-alpha",
+  "version": "0.9.0-alpha",
   "description": "A Javascript library for state management in React applications",
   "main": "dist/node/marty.js",
   "browser": "marty.js",
@@ -60,7 +60,7 @@
     "uglify-js": "^2.4.15"
   },
   "peerDependencies": {
-    "react": ">=0.12.0"
+    "react": ">=0.13.0-rc2"
   },
   "author": "James Hollingworth",
   "licenses": [


### PR DESCRIPTION
Set `react`'s `peerDependency` to `>=0.13.0-rc2` as `>=0.12.0` wouldn't load it. Also set the right version for `marty`.