### PR TITLE
Support dataType and contentType

### DIFF
--- a/docs/_api/state-sources/http.md
+++ b/docs/_api/state-sources/http.md
@@ -108,6 +108,12 @@ class UsersAPI extends Marty.HttpStateSource {
      <td>application/json</td>
      <td>Content type of request</td>
    </tr>
+   <tr>
+     <td>dataType</td>
+     <td>string</td>
+     <td>json</td>
+     <td>The type of data that you're expecting back from the server. <code>xml</code>, <code>json</code>, <code>script</code>, or <code>html</code></td>
+   </tr>
   </tbody>
 </table>
 

--- a/docs/_api/state-sources/http.md
+++ b/docs/_api/state-sources/http.md
@@ -47,7 +47,8 @@ var UsersAPI = Marty.createStateSource({
     this.request({
       url: '/users',
       method: 'POST',
-      body: { name: 'foo' }
+      body: { name: 'foo' },
+      contentType: 'application/json'
     });
   }
 });

--- a/lib/stateSource/inbuilt/http.js
+++ b/lib/stateSource/inbuilt/http.js
@@ -72,6 +72,10 @@ function requestOptions(method, source, options) {
     });
   }
 
+  _.defaults(options, {
+    headers: {}
+  });
+
   options.method = method.toLowerCase();
 
   if (baseUrl) {
@@ -88,6 +92,10 @@ function requestOptions(method, source, options) {
     }
 
     options.url = baseUrl + separator + options.url;
+  }
+
+  if (options.contentType) {
+    options.headers['Content-Type'] = options.contentType;
   }
 
   return options;

--- a/lib/stateSource/inbuilt/http.js
+++ b/lib/stateSource/inbuilt/http.js
@@ -4,6 +4,13 @@ var hooks = {};
 var log = require('../../logger');
 var _ = require('../../utils/mindash');
 var StateSource = require('../stateSource');
+var accepts = {
+  html: 'text/html',
+  text: 'text/plain',
+  json: 'application/json',
+  xml: 'application/xml, text/xml',
+  script: 'text/javascript, application/javascript, application/x-javascript',
+};
 
 class HttpStateSource extends StateSource {
   constructor(options) {
@@ -96,6 +103,16 @@ function requestOptions(method, source, options) {
 
   if (options.contentType) {
     options.headers['Content-Type'] = options.contentType;
+  }
+
+  if (options.dataType) {
+    var contentType = accepts[options.dataType];
+
+    if (!contentType) {
+      log.warn('Unknown data type ' + options.dataType);
+    } else {
+      options.headers['Accept'] = contentType;
+    }
   }
 
   return options;

--- a/test/browser/lib/mockServer.js
+++ b/test/browser/lib/mockServer.js
@@ -19,7 +19,8 @@ app.use(function (req, res, next) {
     res.json({
       method: method,
       url: req.url,
-      body: req.body
+      body: req.body,
+      accept: req.headers['accept']
     }).end();
   });
 });

--- a/test/browser/stateSources/httpStateSourceSpec.js
+++ b/test/browser/stateSources/httpStateSourceSpec.js
@@ -11,12 +11,14 @@ require('es6-promise').polyfill();
 describeStyles('HttpStateSource', function (styles) {
   this.timeout(10000);
 
-  var API, baseUrl, response;
-  var hook1, hook2, hook3, executionOrder;
+  var API, baseUrl, response, xmlContentType;
+  var hook1, hook2, hook3, executionOrder, jsonContentType;
 
   beforeEach(function () {
     baseUrl = '/stub/';
     warnings.classDoesNotHaveAnId = false;
+    xmlContentType = 'application/xml';
+    jsonContentType = 'application/json';
   });
 
   afterEach(function () {
@@ -221,6 +223,7 @@ describeStyles('HttpStateSource', function (styles) {
       beforeEach(function () {
         return makeRequest('get', {
           url: 'bars/baz',
+          contentType: xmlContentType
         });
       });
 
@@ -257,7 +260,8 @@ describeStyles('HttpStateSource', function (styles) {
 
         return makeRequest('put', {
           url: 'bars/baz',
-          body: expectedBody
+          body: expectedBody,
+          contentType: jsonContentType
         });
       });
 
@@ -294,7 +298,8 @@ describeStyles('HttpStateSource', function (styles) {
 
         return makeRequest('post', {
           url: 'bars/baz',
-          body: expectedBody
+          body: expectedBody,
+          contentType: jsonContentType
         });
       });
 

--- a/test/browser/stateSources/httpStateSourceSpec.js
+++ b/test/browser/stateSources/httpStateSourceSpec.js
@@ -11,7 +11,7 @@ require('es6-promise').polyfill();
 describeStyles('HttpStateSource', function (styles) {
   this.timeout(10000);
 
-  var API, baseUrl, response, xmlContentType;
+  var API, baseUrl, response, xmlContentType, accept;
   var hook1, hook2, hook3, executionOrder, jsonContentType;
 
   beforeEach(function () {
@@ -237,6 +237,67 @@ describeStyles('HttpStateSource', function (styles) {
     });
   });
 
+  describe('#dataType', function () {
+
+    describe('json', function () {
+      beforeEach(function () {
+        return requestDataType('json');
+      });
+
+      it('should convert the data type to accept header', function () {
+        expect(accept).to.eql('application/json');
+      });
+    });
+
+    describe('xml', function () {
+      beforeEach(function () {
+        return requestDataType('xml');
+      });
+
+      it('should convert the data type to accept header', function () {
+        expect(accept).to.eql('application/xml, text/xml');
+      });
+    });
+
+    describe('text', function () {
+      beforeEach(function () {
+        return requestDataType('text');
+      });
+
+      it('should convert the data type to accept header', function () {
+        expect(accept).to.eql('text/plain');
+      });
+    });
+
+
+    describe('html', function () {
+      beforeEach(function () {
+        return requestDataType('html');
+      });
+
+      it('should convert the data type to accept header', function () {
+        expect(accept).to.eql('text/html');
+      });
+    });
+
+    describe('script', function () {
+      beforeEach(function () {
+        return requestDataType('script');
+      });
+
+      it('should convert the data type to accept header', function () {
+        expect(accept).to.eql('text/javascript, application/javascript, application/x-javascript');
+      });
+    });
+
+    function requestDataType(dataType) {
+      return makeRequest('get', {
+        url: 'bars/baz',
+        dataType: dataType
+      });
+    }
+  });
+
   describe('#put()', function () {
     describe('when you pass in a url', function () {
       beforeEach(function () {
@@ -448,6 +509,8 @@ describeStyles('HttpStateSource', function (styles) {
 
   function storeResponse(res) {
     response = res.body;
+    accept = response.accept;
+    delete response.accept;
   }
 
   function makeRequest(method) {


### PR DESCRIPTION
* Add dataType option which behaves the same as in [$.ajax](http://api.jquery.com/jquery.ajax/). Fixes #161 
* Add contentType option that makes it easier to specify content type