### PR TITLE
Add CookieStateSource

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "es6-promise": "^2.0.0",
     "flux": "^2.0.1",
+    "cookies-js": "^1.2.1",
     "isomorphic-fetch": "1.6.0",
     "lodash": "^3.0.0"
   }

--- a/docs/_api/state-sources/cookie.md
+++ b/docs/_api/state-sources/cookie.md
@@ -1,0 +1,53 @@
+---
+layout: page
+title: Cookie State Source
+id: cookie-source-json
+section: State Sources
+---
+
+{% sample %}
+classic
+=======
+var UserCookies = Marty.createStateSource({
+  id: 'UserCookies',
+  type: 'cookie',
+  login: function (user) {
+    this.set(user.id, true)
+  },
+  logout: function(id) {
+    this.expire(id);
+  }
+  isLoggedIn: function (id) {
+    return !!this.get(id);
+  }
+});
+
+es6
+===
+class UserCookies extends Marty.CookieStateSource {
+  constructor(options) {
+    super(options);
+  }
+  login(user) {
+    this.set(user.id, true)
+  },
+  logout(id) {
+    this.expire(id);
+  }
+  isLoggedIn(id) {
+    return !!this.get(id);
+  }
+}
+{% endsample %}
+
+<h2 id="get">get(key)</h2>
+
+Gets the item from the cookie the given key.
+
+<h2 id="set">set(key, value)</h2>
+
+Sets the value to the cookie with the given key.
+
+<h2 id="expire">expire(key)</h2>
+
+Removes the key from the cookie.

--- a/docs/_guides/state-sources/cookie.md
+++ b/docs/_guides/state-sources/cookie.md
@@ -1,0 +1,47 @@
+---
+layout: page
+title: JSON Storage State Source
+id: json-storage-state-source
+section: State Sources
+---
+
+The Cookie State Source allows you to persist key/values to the cookie.
+
+{% sample %}
+classic
+=======
+var UserCookies = Marty.createStateSource({
+  id: 'UserCookies',
+  type: 'cookie',
+  login: function (user) {
+    this.set(user.id, true)
+  },
+  logout: function(id) {
+    this.expire(id);
+  }
+  isLoggedIn: function (id) {
+    return !!this.get(id);
+  }
+});
+
+UserCookies.login('foo');
+
+es6
+===
+class UserCookies extends Marty.CookieStateSource {
+  constructor(options) {
+    super(options);
+  }
+  login(user) {
+    this.set(user.id, true)
+  },
+  logout(id) {
+    this.expire(id);
+  }
+  isLoggedIn(id) {
+    return !!this.get(id);
+  }
+}
+
+UserCookies.login('foo')
+{% endsample %}

--- a/lib/classes.js
+++ b/lib/classes.js
@@ -5,6 +5,7 @@ module.exports = {
   StateSource: require('./stateSource'),
   ActionCreators: require('./actionCreators'),
   HttpStateSource: require('./stateSource/inbuilt/http'),
+  CookieStateSource: require('./stateSource/inbuilt/cookie'),
   JSONStorageStateSource: require('./stateSource/inbuilt/jsonStorage'),
   LocalStorageStateSource: require('./stateSource/inbuilt/localStorage'),
   SessionStorageStateSource: require('./stateSource/inbuilt/sessionStorage'),

--- a/lib/stateSource/createStateSourceClass.js
+++ b/lib/stateSource/createStateSourceClass.js
@@ -2,6 +2,7 @@ var _ = require('../utils/mindash');
 var StateSource = require('./stateSource');
 var createClass = require('../createClass');
 var HttpStateSource = require('./inbuilt/http');
+var CookieStateSource = require('./inbuilt/cookie');
 var JSONStorageStateSource = require('./inbuilt/jsonStorage');
 var LocalStorageStateSource = require('./inbuilt/localStorage');
 var SessionStorageStateSource = require('./inbuilt/sessionStorage');
@@ -26,6 +27,8 @@ function baseType(type) {
       return LocalStorageStateSource;
     case 'sessionStorage':
       return SessionStorageStateSource;
+    case 'cookie':
+      return CookieStateSource;
     default:
       return StateSource;
   }

--- a/lib/stateSource/inbuilt/cookie.js
+++ b/lib/stateSource/inbuilt/cookie.js
@@ -1,0 +1,39 @@
+var _ = require('../../utils/mindash');
+var cookieFactory = defaultCookieFactory;
+var Instances = require('../../instances');
+var StateSource = require('../stateSource');
+
+class CookieStateSource extends StateSource {
+  constructor(options) {
+    super(_.extend({}, options, {
+      cookies: cookieFactory()
+    }));
+    this._isCookieStateSource = true;
+  }
+
+  get(key) {
+    return getCookies(this).get(key);
+  }
+
+  set(key, value, options) {
+    return getCookies(this).set(key, value, options);
+  }
+
+  expire(key) {
+    return getCookies(this).expire(key);
+  }
+
+  static set cookieFactory(value) {
+    cookieFactory = value;
+  }
+}
+
+function getCookies(source) {
+  return Instances.get(source).cookies;
+}
+
+function defaultCookieFactory() {
+  return require('cookies-js');
+}
+
+module.exports = CookieStateSource;

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "babel": "^4.7.1",
     "babelify": "^5.0.4",
     "bundle-collapser": "^1.0.0",
+    "cookies-js": "^1.2.1",
     "es6-promise": "^2.0.0",
     "flux": "^2.0.1",
     "isomorphic-fetch": "1.6.0",

--- a/test/browser/stateSources/cookieStateSourceSpec.js
+++ b/test/browser/stateSources/cookieStateSourceSpec.js
@@ -1,0 +1,58 @@
+var expect = require('chai').expect;
+var Marty = require('../../../marty');
+var warnings = require('../../../lib/warnings');
+var describeStyles = require('../../lib/describeStyles');
+
+describeStyles('CookieStateSource', function (styles) {
+  var source, cookies;
+
+  beforeEach(function () {
+    cookies = require('cookies-js');
+    source = styles({
+      classic: function () {
+        return Marty.createStateSource({
+          id: 'Cookies',
+          type: 'cookie'
+        });
+      },
+      es6: function () {
+        class Cookies extends Marty.CookieStateSource {
+        }
+
+        return new Cookies();
+      }
+    });
+  });
+
+  describe('#set()', function () {
+    beforeEach(function () {
+      source.set('foo', 'bar');
+    });
+
+    it('should set the key in the cookie', function () {
+      expect(cookies.get('foo')).to.equal('bar');
+    });
+  });
+
+  describe('#get()', function () {
+    beforeEach(function () {
+      cookies.set('foo', 'bar');
+    });
+
+    it('should retrieve data under key in cookie', function () {
+      expect(source.get('foo')).to.equal('bar');
+    });
+  });
+
+  describe('#expire()', function () {
+    beforeEach(function () {
+      cookies.set('foo', 'bar');
+
+      source.expire('foo');
+    });
+
+    it('should retrieve data under key in cookie', function () {
+      expect(source.get('foo')).to.not.exist;
+    });
+  });
+});


### PR DESCRIPTION
Adds a cookie state source which allows you to get/set/expire cookies. Will be useful for isomorphisim
```js
var UserCookies = Marty.createStateSource({
  type: 'cookie',
  login: function (user) {
    this.set(user.id, true)
  },
  logout: function(id) {
    this.expire(id);
  }
  isLoggedIn: function (id) {
    return !!this.get(id);
  }
});
```