### PR TITLE
Batch store updates

### DIFF
--- a/docs/_api/stores/index.md
+++ b/docs/_api/stores/index.md
@@ -265,7 +265,7 @@ listener.dispose();
 
 <h2 id="hasChanged">hasChanged()</h2>
 
-Calls any [registered callbacks](#addChangeListener).
+Calls any [registered callbacks](#addChangeListener). To improve performance listeners will only be notified once for each dispatched action.
 
 {% sample %}
 classic

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -86,7 +86,7 @@ module.exports = function (config) {
   function local() {
     return _.extend(base(), {
       reporters: ['spec'],
-      browsers: ['Chrome', 'ChromeCanary'],
+      browsers: ['Chrome'],
       autoWatch: true,
       singleRun: false,
       colors: true

--- a/lib/actionPayload.js
+++ b/lib/actionPayload.js
@@ -7,6 +7,7 @@ function ActionPayload(options) {
   options || (options = {});
 
   var rollbackHandlers = [];
+  var actionHandledCallbacks = {};
   var status = StatusConstants.PENDING;
   var handlers = options.handlers || [];
 
@@ -18,11 +19,13 @@ function ActionPayload(options) {
 
   this.error = null;
   this.toJSON = toJSON;
+  this.handled = handled;
   this.toString = toString;
   this.rollback = rollback;
   this.internal = !!options.internal;
   this.addViewHandler = addViewHandler;
   this.addStoreHandler = addStoreHandler;
+  this.onActionHandled = onActionHandled;
   this.addRollbackHandler = addRollbackHandler;
   this.timestamp = options.timestamp || new Date();
 
@@ -87,9 +90,15 @@ function ActionPayload(options) {
   }
 
   function rollback() {
-    _.each(rollbackHandlers, function (rollback) {
-      rollback(this.error);
-    }, this);
+    _.each(rollbackHandlers, rollback => rollback(this.error));
+  }
+
+  function handled() {
+    _.each(actionHandledCallbacks, callback => callback());
+  }
+
+  function onActionHandled(id, cb) {
+    actionHandledCallbacks[id] = cb;
   }
 
   function addViewHandler(name, view) {

--- a/lib/dispatcher.js
+++ b/lib/dispatcher.js
@@ -34,5 +34,7 @@ function dispatchAction(options) {
 
   this.dispatch(action);
 
+  action.handled();
+
   return action;
 }

--- a/lib/store/store.js
+++ b/lib/store/store.js
@@ -125,12 +125,20 @@ class Store {
   }
 
   hasChanged(eventArgs) {
-    var instance = getInstance(this);
+    var emitChange = () => {
+      var instance = getInstance(this);
 
-    if (instance) {
-      var emitter = instance.emitter;
+      if (instance) {
+        var emitter = instance.emitter;
 
-      emitter.emit.call(emitter, StoreEvents.CHANGE_EVENT, this.state, this, eventArgs);
+        emitter.emit.call(emitter, StoreEvents.CHANGE_EVENT, this.state, this, eventArgs);
+      }
+    };
+
+    if (this.action) {
+      this.action.onActionHandled(this.id, emitChange);
+    } else {
+      emitChange();
     }
   }
 

--- a/test/browser/storeSpec.js
+++ b/test/browser/storeSpec.js
@@ -1,6 +1,5 @@
 var _ = require('lodash');
 var sinon = require('sinon');
-var Marty = require('../../marty');
 var expect = require('chai').expect;
 var Dispatcher = require('../../lib/dispatcher');
 var stubbedLogger = require('../lib/stubbedLogger');
@@ -12,9 +11,11 @@ var ActionPredicateUndefinedError = require('../../errors/actionPredicateUndefin
 describeStyles('Store', function (styles, currentStyle) {
   var store, changeListener, listener, dispatcher, dispatchToken = 'foo', initialState = {};
   var actualAction, actualChangeListenerFunctionContext, expectedChangeListenerFunctionContext;
-  var expectedError, logger;
+  var expectedError, logger, Marty;
 
   beforeEach(function () {
+    Marty = require('../../marty').createInstance();
+
     logger = stubbedLogger();
     dispatcher = {
       register: sinon.stub().returns(dispatchToken),
@@ -159,6 +160,34 @@ describeStyles('Store', function (styles, currentStyle) {
       });
     });
   }
+
+  describe('when the store updates multiple times during a dispatch', function () {
+    beforeEach(function () {
+      var dispatcher = Marty.Dispatcher.getDefault();
+
+      var FooStore = Marty.createStore({
+        handlers: {
+          foo: 'FOO'
+        },
+        foo: function () {
+          this.hasChanged();
+          this.hasChanged();
+          this.hasChanged();
+        }
+      });
+
+      changeListener = sinon.spy();
+      FooStore.addChangeListener(changeListener);
+      dispatcher.dispatchAction({
+        type: 'FOO',
+        arguments: []
+      });
+    });
+
+    it('should only notify components once at the end of the dispatch', function () {
+      expect(changeListener).to.be.calledOnce;
+    });
+  });
 
   describe('#state', function () {
     var newState;


### PR DESCRIPTION
Stores change listeners will only be notified once for each action dispatched. This is so we don't unnecessarily cause components to re-render (As [discussed on the flux panel](https://www.youtube.com/watch?v=LTj4O7WJJ98&list=PLb0IAmt7-GS1cbw4qonlQztYV1TAW0sCr#t=473))