### PR TITLE
Store#fetch: Allow "falsy" IDs such as 0

### DIFF
--- a/lib/store.js
+++ b/lib/store.js
@@ -161,7 +161,7 @@ function Store(options) {
       remotely: _.noop
     });
 
-    if (!options || !options.id) {
+    if (!options || typeof options.id == 'undefined' || typeof options.id == 'null') {
       throw new Error('must specify an id');
     }
 

--- a/test/storeFetchTest.js
+++ b/test/storeFetchTest.js
@@ -283,6 +283,12 @@ describe('Store#fetch()', function () {
     });
   });
 
+  describe('when you pass valid, but falsy id', function () {
+    it('should not throw an error', function () {
+      expect(function () { store.fetch({id: 0}); }).not.to.throw(Error);
+    });
+  });
+
   describe('when a fetch with the given id is in progress', function () {
     beforeEach(function () {
       expectedResult = store.fetch(fetchId, noop, function () {


### PR DESCRIPTION
Currently, when you pass an ID to `Marty.Store#fetch` which is not `null` or `undefined`, but "falsy" according to JavaScript's logic (such as 0 or the empty string), an exception with the message `must specify an id` is thrown. This pull request fixes that and makes sure to only throw an exception if either `undefined` or `null` is passed, but not for any other value.