### PR TITLE
Added credentials = include for fetch

### DIFF
--- a/lib/stateSources/http.js
+++ b/lib/stateSources/http.js
@@ -24,6 +24,10 @@ function HttpStateSource(mixinOptions) {
         options.headers[CONTENT_TYPE] = JSON_CONTENT_TYPE;
       }
 
+      // Enable sending Cookies for authentication.
+      // Ref: https://fetch.spec.whatwg.org/#concept-request-credentials-mode
+      options.credentials = 'include';
+
       return fetch(options.url, options).then(function (res) {
         if (res.status >= 400) {
           throw res;


### PR DESCRIPTION
Now that Chrome 42 is on the beta channel we will start to use the native fetch implementation. This varies in a lot of ways form a traditional XHR request. One of the most obvious is that it omits sending cookies by default. This PR changes that default to `include` mode, which is similar to what we're used to.