### PR TITLE
Use let instead of var

### DIFF
--- a/build/updateVersion.js
+++ b/build/updateVersion.js
@@ -1,9 +1,9 @@
-var fs = require('fs');
-var util = require('util');
-var semver = require('semver');
-var join = require('path').join;
-var inc = process.env.inc || 'patch';
-var version = semver.inc(require('../package.json').version, inc);
+let fs = require('fs');
+let util = require('util');
+let semver = require('semver');
+let join = require('path').join;
+let inc = process.env.inc || 'patch';
+let version = semver.inc(require('../package.json').version, inc);
 
 console.log(version)
 
@@ -13,19 +13,19 @@ updateVersion();
 ['../package.json', '../bower.json'].forEach(updateConfig);
 
 function updateDocs() {
-  var config = read('../docs/_config.yml');
+  let config = read('../docs/_config.yml');
   config = config.replace(/current_version: .*/, util.format("current_version: %s", version));
   write('../docs/_config.yml', config);
 }
 
 function updateMarty() {
-  var marty = read('../marty.js');
+  let marty = read('../marty.js');
   marty = marty.replace(/version: '.*'/, util.format("version: '%s'", version));
   write('../marty.js', marty);
 }
 
 function updateConfig(path) {
-  var config = JSON.parse(read(path));
+  let config = JSON.parse(read(path));
   config.version = version;
   write(path, JSON.stringify(config, null, 2));
 }

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,6 +1,6 @@
-var fs = require('fs');
-var _ = require('lodash');
-var yaml = require('js-yaml');
+let fs = require('fs');
+let _ = require('lodash');
+let yaml = require('js-yaml');
 
 module.exports = function (config) {
   process.env.NODE_ENV = 'test';
@@ -31,7 +31,7 @@ module.exports = function (config) {
   }
 
   function saucelabs() {
-    var customLaunchers = {
+    let customLaunchers = {
       sl_chrome: {
         base: 'SauceLabs',
         browserName: 'chrome',
@@ -126,11 +126,11 @@ module.exports = function (config) {
     return _.pick(travisGlobalVariables(), 'SAUCE_USERNAME', 'SAUCE_ACCESS_KEY');
 
     function travisGlobalVariables() {
-      var config = {};
-      var travis = yaml.safeLoad(fs.readFileSync('./.travis.yml', 'utf-8'));
+      let config = {};
+      let travis = yaml.safeLoad(fs.readFileSync('./.travis.yml', 'utf-8'));
 
-      travis.env.global.forEach(function (variable) {
-        var parts = /(.*)="(.*)"/.exec(variable);
+      travis.env.global.forEach(function (letiable) {
+        let parts = /(.*)="(.*)"/.exec(letiable);
 
         config[parts[1]] = parts[2];
       });

--- a/lib/actionCreators/actionCreators.js
+++ b/lib/actionCreators/actionCreators.js
@@ -1,4 +1,4 @@
-var DispatchCoordinator = require('../dispatchCoordinator');
+let DispatchCoordinator = require('../dispatchCoordinator');
 
 class ActionCreators extends DispatchCoordinator {
   constructor(options) {

--- a/lib/actionCreators/autoDispatch.js
+++ b/lib/actionCreators/autoDispatch.js
@@ -1,8 +1,8 @@
-var _ = require('../utils/mindash');
+let _ = require('../utils/mindash');
 
 function autoDispatch(constant) {
   return function () {
-    var args = _.toArray(arguments);
+    let args = _.toArray(arguments);
 
     args.unshift(constant);
 

--- a/lib/actionCreators/createActionCreatorsClass.js
+++ b/lib/actionCreators/createActionCreatorsClass.js
@@ -1,7 +1,7 @@
-var _ = require('../utils/mindash');
-var createClass = require('../createClass');
-var ActionCreators = require('./actionCreators');
-var RESERVED_KEYWORDS = ['dispatch'];
+let _ = require('../utils/mindash');
+let createClass = require('../createClass');
+let ActionCreators = require('./actionCreators');
+let RESERVED_KEYWORDS = ['dispatch'];
 
 function createActionCreatorsClass(properties) {
   _.extend.apply(_, [properties].concat(properties.mixins));
@@ -11,7 +11,7 @@ function createActionCreatorsClass(properties) {
     }
   });
 
-  var classProperties = _.omit(properties, 'mixins', 'types');
+  let classProperties = _.omit(properties, 'mixins', 'types');
 
   return createClass(classProperties, properties, ActionCreators);
 }

--- a/lib/actionPayload.js
+++ b/lib/actionPayload.js
@@ -1,13 +1,13 @@
-var _ = require('./utils/mindash');
-var uuid = require('./utils/uuid');
+let _ = require('./utils/mindash');
+let uuid = require('./utils/uuid');
 
 function ActionPayload(options) {
   options || (options = {});
 
-  var stores = [];
-  var components = [];
-  var rollbackHandlers = [];
-  var actionHandledCallbacks = {};
+  let stores = [];
+  let components = [];
+  let rollbackHandlers = [];
+  let actionHandledCallbacks = {};
 
   _.extend(this, options);
 
@@ -50,7 +50,7 @@ function ActionPayload(options) {
   }
 
   function toJSON() {
-    var json = _.pick(this,
+    let json = _.pick(this,
       'id',
       'type',
       'stores',

--- a/lib/components/context.js
+++ b/lib/components/context.js
@@ -1,7 +1,7 @@
-var React = require('../react');
-var _ = require('../utils/mindash');
+let React = require('../react');
+let _ = require('../utils/mindash');
 
-var Context = React.createClass({
+let Context = React.createClass({
   childContextTypes: {
     marty: React.PropTypes.object.isRequired
   },
@@ -11,8 +11,8 @@ var Context = React.createClass({
     };
   },
   render: function () {
-    var subject = this.props.subject;
-    var props = _.extend({}, subject.props, { ref: 'subject' });
+    let subject = this.props.subject;
+    let props = _.extend({}, subject.props, { ref: 'subject' });
 
     return React.createElement(subject.type, props);
   }

--- a/lib/constants/index.js
+++ b/lib/constants/index.js
@@ -1,6 +1,6 @@
-var log = require('../logger');
-var _ = require('../utils/mindash');
-var warnings = require('../warnings');
+let log = require('../logger');
+let _ = require('../utils/mindash');
+let warnings = require('../warnings');
 
 function constants(obj) {
   return toConstant(obj);
@@ -28,10 +28,10 @@ function constants(obj) {
   }
 
   function arrayToConstants(array) {
-    var constants = {};
+    let constants = {};
 
     _.each(array, function (actionType) {
-      var types = [
+      let types = [
         actionType,
         actionType + '_STARTING',
         actionType + '_DONE',
@@ -47,7 +47,7 @@ function constants(obj) {
   }
 
   function createActionCreator(actionType) {
-    var constantActionCreator = function (actionCreator) {
+    let constantActionCreator = function (actionCreator) {
       if (warnings.invokeConstant) {
         log.warn(
           'Warning: Invoking constants has been depreciated. ' +
@@ -61,14 +61,14 @@ function constants(obj) {
       }
 
       return function () {
-        var context = actionContext(this);
+        let context = actionContext(this);
 
         actionCreator.apply(context, arguments);
 
         function actionContext(creators) {
           return _.extend({}, creators, {
             dispatch: function () {
-              var args = _.toArray(arguments);
+              let args = _.toArray(arguments);
 
               args.unshift(actionType);
 

--- a/lib/constants/status.js
+++ b/lib/constants/status.js
@@ -1,3 +1,3 @@
-var constants = require('./index');
+let constants = require('./index');
 
 module.exports = constants(['PENDING', 'FAILED', 'DONE']);

--- a/lib/constants/store.js
+++ b/lib/constants/store.js
@@ -1,3 +1,3 @@
-var constants = require('./index');
+let constants = require('./index');
 
 module.exports = constants(['FETCH_FAILED']);

--- a/lib/context.js
+++ b/lib/context.js
@@ -1,12 +1,12 @@
-var _ = require('./utils/mindash');
-var uuid = require('./utils/uuid');
-var Instances = require('./instances');
-var timeout = require('./utils/timeout');
-var Dispatcher = require('./dispatcher');
-var deferred = require('./utils/deferred');
-var FetchDiagnostics = require('./fetchDiagnostics');
+let _ = require('./utils/mindash');
+let uuid = require('./utils/uuid');
+let Instances = require('./instances');
+let timeout = require('./utils/timeout');
+let Dispatcher = require('./dispatcher');
+let deferred = require('./utils/deferred');
+let FetchDiagnostics = require('./fetchDiagnostics');
 
-var DEFAULT_TIMEOUT = 1000;
+let DEFAULT_TIMEOUT = 1000;
 
 class Context {
   constructor(registry) {
@@ -17,7 +17,7 @@ class Context {
     Instances.add(this);
 
     _.each((registry || {}).types, (classes, type) => {
-      var options = {
+      let options = {
         context: this,
         dispatcher: this.dispatcher
       };
@@ -35,8 +35,8 @@ class Context {
   }
 
   fetch(cb, options) {
-    var fetchDone;
-    var instance = getInstance(this);
+    let fetchDone;
+    let instance = getInstance(this);
 
     options = _.defaults(options || {}, {
       timeout: DEFAULT_TIMEOUT
@@ -64,14 +64,14 @@ class Context {
   }
 
   fetchStarted(storeId, fetchId) {
-    var diagnostics = getInstance(this).diagnostics;
+    let diagnostics = getInstance(this).diagnostics;
 
     diagnostics.fetchStarted(storeId, fetchId);
   }
 
   fetchDone(storeId, fetchId, status, options) {
-    var instance = getInstance(this);
-    var diagnostics = instance.diagnostics;
+    let instance = getInstance(this);
+    let diagnostics = instance.diagnostics;
 
     diagnostics.fetchDone(storeId, fetchId, status, options);
 
@@ -100,8 +100,8 @@ class Context {
       throw new Error('Cannot resolve object');
     }
 
-    var id = obj.constructor.id;
-    var type = obj.constructor.type;
+    let id = obj.constructor.id;
+    let type = obj.constructor.type;
 
     if (!this.instances[type]) {
       throw new Error(`Context does not have any instances of ${type}`);

--- a/lib/create.js
+++ b/lib/create.js
@@ -1,11 +1,11 @@
-var constants = require('./constants');
-var StateMixin = require('./stateMixin');
-var createContainer = require('./createContainer');
-var createStoreClass = require('./store/createStoreClass');
-var createQueriesClass = require('./queries/createQueriesClass');
-var createStateSourceClass = require('./stateSource/createStateSourceClass');
-var createActionCreatorsClass = require('./actionCreators/createActionCreatorsClass');
-var DEFAULT_CLASS_NAME = 'Class';
+let constants = require('./constants');
+let StateMixin = require('./stateMixin');
+let createContainer = require('./createContainer');
+let createStoreClass = require('./store/createStoreClass');
+let createQueriesClass = require('./queries/createQueriesClass');
+let createStateSourceClass = require('./stateSource/createStateSourceClass');
+let createActionCreatorsClass = require('./actionCreators/createActionCreatorsClass');
+let DEFAULT_CLASS_NAME = 'Class';
 
 module.exports = {
   register: register,
@@ -20,7 +20,7 @@ module.exports = {
 };
 
 function register(clazz, id) {
-  var className = getClassName(clazz);
+  let className = getClassName(clazz);
 
   if (!clazz.id) {
     clazz.id = id || className;
@@ -38,9 +38,9 @@ function createContext() {
 }
 
 function getClassName(clazz) {
-  var funcNameRegex = /function (.{1,})\(/;
-  var results = (funcNameRegex).exec(clazz.toString());
-  var className = (results && results.length > 1) ? results[1] : '';
+  let funcNameRegex = /function (.{1,})\(/;
+  let results = (funcNameRegex).exec(clazz.toString());
+  let className = (results && results.length > 1) ? results[1] : '';
 
   return className === DEFAULT_CLASS_NAME ? null : className;
 }
@@ -54,29 +54,29 @@ function createStateMixin(options) {
 }
 
 function createStore(properties) {
-  var StoreClass = createStoreClass(properties);
-  var defaultInstance = this.register(StoreClass);
+  let StoreClass = createStoreClass(properties);
+  let defaultInstance = this.register(StoreClass);
 
   return defaultInstance;
 }
 
 function createActionCreators(properties) {
-  var ActionCreatorsClass = createActionCreatorsClass(properties);
-  var defaultInstance = this.register(ActionCreatorsClass);
+  let ActionCreatorsClass = createActionCreatorsClass(properties);
+  let defaultInstance = this.register(ActionCreatorsClass);
 
   return defaultInstance;
 }
 
 function createQueries(properties) {
-  var QueriesClass = createQueriesClass(properties);
-  var defaultInstance = this.register(QueriesClass);
+  let QueriesClass = createQueriesClass(properties);
+  let defaultInstance = this.register(QueriesClass);
 
   return defaultInstance;
 }
 
 function createStateSource(properties) {
-  var StateSourceClass = createStateSourceClass(properties);
-  var defaultInstance = this.register(StateSourceClass);
+  let StateSourceClass = createStateSourceClass(properties);
+  let defaultInstance = this.register(StateSourceClass);
 
   return defaultInstance;
 }

--- a/lib/createClass.js
+++ b/lib/createClass.js
@@ -1,4 +1,4 @@
-var _ = require('./utils/mindash');
+let _ = require('./utils/mindash');
 
 function createClass(properties, defaultOptions, BaseType) {
   function Class(options) {
@@ -6,8 +6,8 @@ function createClass(properties, defaultOptions, BaseType) {
     this.id = properties.id;
     this.displayName = properties.displayName;
 
-    var base = get(Object.getPrototypeOf(Class.prototype), 'constructor', this);
-    var baseOptions = _.extend({}, defaultOptions, options, properties);
+    let base = get(Object.getPrototypeOf(Class.prototype), 'constructor', this);
+    let baseOptions = _.extend({}, defaultOptions, options, properties);
 
     base.call(this, baseOptions);
   }
@@ -25,9 +25,9 @@ function createClass(properties, defaultOptions, BaseType) {
 }
 
 function get(object, property, receiver) {
-  var desc = Object.getOwnPropertyDescriptor(object, property);
+  let desc = Object.getOwnPropertyDescriptor(object, property);
   if (desc === undefined) {
-    var parent = Object.getPrototypeOf(object);
+    let parent = Object.getPrototypeOf(object);
     if (parent === null) {
       return undefined;
     } else {
@@ -36,7 +36,7 @@ function get(object, property, receiver) {
   } else if ('value' in desc && desc.writable) {
     return desc.value;
   } else {
-    var getter = desc.get;
+    let getter = desc.get;
     if (getter === undefined) {
       return undefined;
     }

--- a/lib/createContainer/createContainer.js
+++ b/lib/createContainer/createContainer.js
@@ -1,9 +1,9 @@
-var React = require('react');
-var log = require('../logger');
-var _ = require('../utils/mindash');
-var uuid = require('../utils/uuid');
-var StoreObserver = require('../storeObserver');
-var getFetchResult = require('./getFetchResult');
+let React = require('react');
+let log = require('../logger');
+let _ = require('../utils/mindash');
+let uuid = require('../utils/uuid');
+let StoreObserver = require('../storeObserver');
+let getFetchResult = require('./getFetchResult');
 
 function createContainer(InnerComponent, config) {
   config = config || {};
@@ -12,15 +12,15 @@ function createContainer(InnerComponent, config) {
     throw new Error('Must specify an inner component');
   }
 
-  var observer;
-  var id = uuid.type('Component');
+  let observer;
+  let id = uuid.type('Component');
 
-  var Container = React.createClass({
+  let Container = React.createClass({
     contextTypes: {
       marty: React.PropTypes.object
     },
     componentDidMount() {
-      var component = {
+      let component = {
         id: id,
         displayName: InnerComponent.displayName
       };
@@ -97,7 +97,7 @@ function createContainer(InnerComponent, config) {
 module.exports = createContainer;
 
 function getStoresToListenTo(config, component) {
-  var stores = config.listenTo;
+  let stores = config.listenTo;
 
   if (!stores) {
     return [];
@@ -108,7 +108,7 @@ function getStoresToListenTo(config, component) {
   }
 
   return _.filter(stores, function (store) {
-    var isStore = store.constructor.type === 'Store';
+    let isStore = store.constructor.type === 'Store';
 
     if (!isStore) {
       log.warn(

--- a/lib/createContainer/getFetchResult.js
+++ b/lib/createContainer/getFetchResult.js
@@ -1,13 +1,13 @@
-var log = require('../logger');
-var _ = require('../utils/mindash');
-var fetch = require('../store/fetchResult');
+let log = require('../logger');
+let _ = require('../utils/mindash');
+let fetch = require('../store/fetchResult');
 
 function getFetchResult(config) {
-  var errors = {};
-  var results = {};
-  var isPending = false;
-  var hasFailed = false;
-  var fetches = invokeFetches(config);
+  let errors = {};
+  let results = {};
+  let isPending = false;
+  let hasFailed = false;
+  let fetches = invokeFetches(config);
 
   _.each(fetches, (fetch, key) => {
     if (fetch.done) {
@@ -32,10 +32,10 @@ function getFetchResult(config) {
 }
 
 function invokeFetches(config) {
-  var fetches = {};
+  let fetches = {};
 
   if (_.isFunction(config.fetch)) {
-    var result = config.fetch.call(config);
+    let result = config.fetch.call(config);
 
     if (result._isFetchResult) {
       throw new Error(
@@ -56,7 +56,7 @@ function invokeFetches(config) {
       if (!_.isFunction(getResult)) {
         log.warn(`The fetch ${key} was not a function and so ignoring`);
       } else {
-        var result = getResult.call(config);
+        let result = getResult.call(config);
 
         if (!result || !result._isFetchResult) {
           result = fetch.done(result);

--- a/lib/diagnostics.js
+++ b/lib/diagnostics.js
@@ -1,4 +1,4 @@
-var diagnostics = {
+let diagnostics = {
   trace: trace,
   enabled: false,
   devtoolsEnabled: false,

--- a/lib/dispatchCoordinator.js
+++ b/lib/dispatchCoordinator.js
@@ -1,9 +1,9 @@
-var log = require('./logger');
-var uuid = require('./utils/uuid');
-var warnings = require('./warnings');
-var Instances = require('./instances');
-var resolve = require('./utils/resolve');
-var Environment = require('./environment');
+let log = require('./logger');
+let uuid = require('./utils/uuid');
+let warnings = require('./warnings');
+let Instances = require('./instances');
+let resolve = require('./utils/resolve');
+let Environment = require('./environment');
 
 class DispatchCoordinator {
   constructor(type, options) {
@@ -18,7 +18,7 @@ class DispatchCoordinator {
   }
 
   dispatch(type, ...args) {
-    var dispatcher = getInstance(this).dispatcher;
+    let dispatcher = getInstance(this).dispatcher;
 
     return dispatcher.dispatchAction({
       type: type,

--- a/lib/dispatcher.js
+++ b/lib/dispatcher.js
@@ -1,10 +1,10 @@
-var _ = require('./utils/mindash');
-var uuid = require('./utils/uuid');
-var Dispatcher = require('flux').Dispatcher;
-var ActionPayload = require('./actionPayload');
-var EventEmitter = require('events').EventEmitter;
-var defaultDispatcher = createDefaultDispatcher();
-var ACTION_DISPATCHED = 'ACTION_DISPATCHED';
+let _ = require('./utils/mindash');
+let uuid = require('./utils/uuid');
+let Dispatcher = require('flux').Dispatcher;
+let ActionPayload = require('./actionPayload');
+let EventEmitter = require('events').EventEmitter;
+let defaultDispatcher = createDefaultDispatcher();
+let ACTION_DISPATCHED = 'ACTION_DISPATCHED';
 
 createDispatcher.getDefault = function () {
   return defaultDispatcher;
@@ -17,19 +17,19 @@ createDispatcher.dispose = function () {
 module.exports = createDispatcher;
 
 function createDefaultDispatcher() {
-  var defaultDispatcher = createDispatcher();
+  let defaultDispatcher = createDispatcher();
   defaultDispatcher.isDefault = true;
   return defaultDispatcher;
 }
 
 function createDispatcher() {
-  var emitter = new EventEmitter();
-  var dispatcher = new Dispatcher();
+  let emitter = new EventEmitter();
+  let dispatcher = new Dispatcher();
 
   dispatcher.id = uuid.generate();
   dispatcher.isDefault = false;
   dispatcher.dispatchAction = function (options) {
-    var action = new ActionPayload(options);
+    let action = new ActionPayload(options);
 
     this.dispatch(action);
 

--- a/lib/dispose.js
+++ b/lib/dispose.js
@@ -1,4 +1,4 @@
-var Dispatcher = require('./dispatcher');
+let Dispatcher = require('./dispatcher');
 
 function dispose() {
   Dispatcher.dispose();

--- a/lib/environment.js
+++ b/lib/environment.js
@@ -1,5 +1,5 @@
-var windowDefined = typeof window !== 'undefined';
-var environment = windowDefined ? 'browser' : 'server';
+let windowDefined = typeof window !== 'undefined';
+let environment = windowDefined ? 'browser' : 'server';
 
 module.exports = {
   environment: environment,

--- a/lib/errors/actionHandlerNotFound.js
+++ b/lib/errors/actionHandlerNotFound.js
@@ -3,7 +3,7 @@ function ActionHandlerNotFoundError(actionHandler, store) {
   this.message = 'The action handler "' + actionHandler + '" could not be found';
 
   if (store) {
-    var displayName = store.displayName || store.id;
+    let displayName = store.displayName || store.id;
     this.message += ' in the ' + displayName + ' store';
   }
 }

--- a/lib/errors/actionPredicateUndefined.js
+++ b/lib/errors/actionPredicateUndefined.js
@@ -3,7 +3,7 @@ function ActionPredicateUndefinedError(actionHandler, store) {
   this.message = 'The action predicate for "' + actionHandler + '" was undefined';
 
   if (store) {
-    var displayName = store.displayName || store.id;
+    let displayName = store.displayName || store.id;
     this.message += ' in the ' + displayName + ' store';
   }
 }

--- a/lib/fetchDiagnostics.js
+++ b/lib/fetchDiagnostics.js
@@ -1,4 +1,4 @@
-var _ = require('./utils/mindash');
+let _ = require('./utils/mindash');
 
 class FetchDiagnostics {
   constructor() {
@@ -17,7 +17,7 @@ class FetchDiagnostics {
   }
 
   fetchDone(storeId, fetchId, status, options) {
-    var fetch  = _.find(this.fetches, {
+    let fetch  = _.find(this.fetches, {
       storeId: storeId,
       fetchId: fetchId
     });

--- a/lib/instances.js
+++ b/lib/instances.js
@@ -1,13 +1,13 @@
-var instances = {};
-var _ = require('./utils/mindash');
-var Dispatcher = require('./dispatcher');
+let instances = {};
+let _ = require('./utils/mindash');
+let Dispatcher = require('./dispatcher');
 
-var Instances = {
+let Instances = {
   get(obj) {
     return instances[this.getId(obj)];
   },
   getId(obj) {
-    var id = obj.__id;
+    let id = obj.__id;
 
     if (!id) {
       id = obj.id;
@@ -22,7 +22,7 @@ var Instances = {
   add(obj, instance) {
     instance = instance || {};
 
-    var id = this.getId(obj);
+    let id = this.getId(obj);
 
     if (instances[id]) {
       throw new Error(`There is already an instance for the ${instance.__type} id`);

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,5 +1,5 @@
-var _ = require('./utils/mindash');
-var Diagnostics = require('./diagnostics');
+let _ = require('./utils/mindash');
+let Diagnostics = require('./diagnostics');
 
 if (console) {
   module.exports = console;

--- a/lib/queries/createQueriesClass.js
+++ b/lib/queries/createQueriesClass.js
@@ -1,7 +1,7 @@
-var Queries = require('./queries');
-var _ = require('../utils/mindash');
-var RESERVED_KEYWORDS = ['dispatch'];
-var createClass = require('../createClass');
+let Queries = require('./queries');
+let _ = require('../utils/mindash');
+let RESERVED_KEYWORDS = ['dispatch'];
+let createClass = require('../createClass');
 
 function createQueriesClass(properties) {
   _.extend.apply(_, [properties].concat(properties.mixins));
@@ -11,7 +11,7 @@ function createQueriesClass(properties) {
     }
   });
 
-  var classProperties = _.omit(properties, 'mixins', 'types');
+  let classProperties = _.omit(properties, 'mixins', 'types');
 
   return createClass(classProperties, properties, Queries);
 }

--- a/lib/queries/queries.js
+++ b/lib/queries/queries.js
@@ -1,4 +1,4 @@
-var DispatchCoordinator = require('../dispatchCoordinator');
+let DispatchCoordinator = require('../dispatchCoordinator');
 
 class Queries extends DispatchCoordinator {
   constructor(options) {

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -1,16 +1,16 @@
-var _ = require('./utils/mindash');
-var log = require('./logger');
-var Store = require('./store');
-var Queries = require('./queries');
-var Context = require('./context');
-var warnings = require('./warnings');
-var classId = require('./utils/classId');
-var Environment = require('./environment');
-var StateSource = require('./stateSource');
-var ActionCreators = require('./actionCreators');
-var humanStrings = require('./utils/humanStrings');
+let _ = require('./utils/mindash');
+let log = require('./logger');
+let Store = require('./store');
+let Queries = require('./queries');
+let Context = require('./context');
+let warnings = require('./warnings');
+let classId = require('./utils/classId');
+let Environment = require('./environment');
+let StateSource = require('./stateSource');
+let ActionCreators = require('./actionCreators');
+let humanStrings = require('./utils/humanStrings');
 
-var FUNCTIONS_TO_NOT_WRAP = ['fetch'];
+let FUNCTIONS_TO_NOT_WRAP = ['fetch'];
 
 class Registry {
   constructor() {
@@ -43,8 +43,8 @@ class Registry {
   }
 
   register(clazz) {
-    var defaultInstance = new clazz({});
-    var type = classType(defaultInstance);
+    let defaultInstance = new clazz({});
+    let type = classType(defaultInstance);
 
     defaultInstance.__isDefaultInstance = true;
 
@@ -56,7 +56,7 @@ class Registry {
       this.defaults[type] = {};
     }
 
-    var id = classId(clazz, type);
+    let id = classId(clazz, type);
 
     if (!id) {
       throw CannotRegisterClassError(clazz, type);
@@ -81,7 +81,7 @@ class Registry {
   }
 
   resolve(type, id, options) {
-    var clazz = (this.types[type] || {})[id];
+    let clazz = (this.types[type] || {})[id];
 
     if (!clazz) {
       throw CannotFindTypeWithId(type, id);
@@ -124,14 +124,14 @@ function wrapResolverFunctions(functionName) {
     return;
   }
 
-  var instance = this;
-  var originalFunc = instance[functionName];
+  let instance = this;
+  let originalFunc = instance[functionName];
 
   instance[functionName] = function () {
     if (warnings.callingResolverOnServer && Environment.isServer) {
-      var type = instance.__type;
-      var displayName = instance.displayName || instance.id;
-      var warningMessage =
+      let type = instance.__type;
+      let displayName = instance.displayName || instance.id;
+      let warningMessage =
         `Warning: You are calling \`${functionName}\` on the static instance of the ${type} ` +
         `'${displayName}'. You should resolve the instance for the current context`;
 
@@ -144,8 +144,8 @@ function wrapResolverFunctions(functionName) {
 
 
 function addTypeHelpers(type) {
-  var proto = Registry.prototype;
-  var pluralType = type;
+  let proto = Registry.prototype;
+  let pluralType = type;
 
   if (pluralType[pluralType.length - 1] !== 's') {
     pluralType += 's';
@@ -159,7 +159,7 @@ function addTypeHelpers(type) {
 
   function partial(func, type) {
     return function () {
-      var args = _.toArray(arguments);
+      let args = _.toArray(arguments);
       args.unshift(type);
       return func.apply(this, args);
     };
@@ -171,9 +171,9 @@ function CannotFindTypeWithId(type, id) {
 }
 
 function CannotRegisterClassError(clazz, type) {
-  var displayName = clazz.displayName || clazz.id;
-  var typeDisplayName = humanStrings[type] || type;
-  var warningPrefix = `Cannot register the ${typeDisplayName}`;
+  let displayName = clazz.displayName || clazz.id;
+  let typeDisplayName = humanStrings[type] || type;
+  let warningPrefix = `Cannot register the ${typeDisplayName}`;
 
   if (displayName) {
     warningPrefix += ` '${displayName}'`;
@@ -183,9 +183,9 @@ function CannotRegisterClassError(clazz, type) {
 }
 
 function ClassAlreadyRegisteredWithId(clazz, type) {
-  var displayName = clazz.displayName || clazz.id;
-  var typeDisplayName = humanStrings[type] || type;
-  var warningPrefix = `Cannot register the ${typeDisplayName}`;
+  let displayName = clazz.displayName || clazz.id;
+  let typeDisplayName = humanStrings[type] || type;
+  let warningPrefix = `Cannot register the ${typeDisplayName}`;
 
   if (displayName) {
     warningPrefix += ` '${displayName}'`;

--- a/lib/renderToString.js
+++ b/lib/renderToString.js
@@ -1,13 +1,13 @@
-var React = require('./react');
-var Context = require('./context');
-var ContextComponent = require('./components/context');
+let React = require('./react');
+let Context = require('./context');
+let ContextComponent = require('./components/context');
 
 function renderToString(options) {
   options = options || {};
 
-  var Marty = this;
-  var context = options.context;
-  var fetchOptions = { timeout: options.timeout };
+  let Marty = this;
+  let context = options.context;
+  let fetchOptions = { timeout: options.timeout };
 
   return new Promise(function (resolve, reject) {
     if (!options.type) {
@@ -30,14 +30,14 @@ function renderToString(options) {
     function dehydrateAndRenderHtml(diagnostics) {
       context.fetch(function () {
         try {
-          var element = createElement();
+          let element = createElement();
 
           if (!element) {
             reject(new Error('createElement must return an element'));
             return;
           }
 
-          var html = React.renderToString(element);
+          let html = React.renderToString(element);
           html += dehydratedState(context);
           resolve({
             html: html,
@@ -54,7 +54,7 @@ function renderToString(options) {
     function startFetches() {
       return context.fetch(function () {
         try {
-          var element = createElement();
+          let element = createElement();
 
           if (!element) {
             reject(new Error('createElement must return an element'));
@@ -69,7 +69,7 @@ function renderToString(options) {
     }
 
     function createElement() {
-      var element = React.createElement(ContextComponent, {
+      let element = React.createElement(ContextComponent, {
         context: context,
         subject: {
           type: options.type,
@@ -81,7 +81,7 @@ function renderToString(options) {
     }
 
     function dehydratedState(context) {
-      var state = Marty.dehydrate(context);
+      let state = Marty.dehydrate(context);
 
       return `<script id="__marty-state">${state}</script>`;
     }

--- a/lib/state.js
+++ b/lib/state.js
@@ -1,9 +1,9 @@
-var log = require('./logger');
-var _ = require('./utils/mindash');
-var Instances = require('./instances');
-var UnknownStoreError = require('./errors/unknownStore');
+let log = require('./logger');
+let _ = require('./utils/mindash');
+let Instances = require('./instances');
+let UnknownStoreError = require('./errors/unknownStore');
 
-var SERIALIZED_WINDOW_OBJECT = '__marty';
+let SERIALIZED_WINDOW_OBJECT = '__marty';
 
 module.exports = {
   rehydrate: rehydrate,
@@ -24,7 +24,7 @@ function clearState() {
 
 function replaceState(states) {
   _.each(getDefaultStores(this), function (store) {
-    var id = storeId(store);
+    let id = storeId(store);
 
     if (states[id]) {
       store.replaceState(states[id]);
@@ -33,18 +33,18 @@ function replaceState(states) {
 }
 
 function rehydrate(storeStates) {
-  var stores = indexById(getDefaultStores(this));
+  let stores = indexById(getDefaultStores(this));
   storeStates = storeStates || getStoreStatesFromWindow();
 
   _.each(storeStates, function (dehydratedStore, storeName) {
-    var store = stores[storeName];
-    var state = dehydratedStore.state;
+    let store = stores[storeName];
+    let state = dehydratedStore.state;
 
     if (!store) {
       throw new UnknownStoreError(storeName);
     }
 
-    var instance = Instances.get(store);
+    let instance = Instances.get(store);
 
     instance.fetchHistory = dehydratedStore.fetchHistory;
 
@@ -80,14 +80,14 @@ function rehydrate(storeStates) {
 }
 
 function dehydrate(context) {
-  var dehydratedStores = {};
-  var stores = context ? context.getAllStores() : getDefaultStores(this);
+  let dehydratedStores = {};
+  let stores = context ? context.getAllStores() : getDefaultStores(this);
 
   _.each(stores, function (store) {
-    var id = storeId(store);
+    let id = storeId(store);
 
     if (id) {
-      var instance = Instances.get(store);
+      let instance = Instances.get(store);
 
       dehydratedStores[id] = {
         fetchHistory: instance.fetchHistory,

--- a/lib/stateMixin.js
+++ b/lib/stateMixin.js
@@ -1,12 +1,12 @@
-var React = require('./react');
-var _ = require('./utils/mindash');
-var uuid = require('./utils/uuid');
-var Instances = require('./instances');
-var StoreObserver = require('./storeObserver');
-var reservedKeys = ['listenTo', 'getState', 'getInitialState'];
+let React = require('./react');
+let _ = require('./utils/mindash');
+let uuid = require('./utils/uuid');
+let Instances = require('./instances');
+let StoreObserver = require('./storeObserver');
+let reservedKeys = ['listenTo', 'getState', 'getInitialState'];
 
 function StateMixin(options) {
-  var config, instanceMethods;
+  let config, instanceMethods;
 
   if (!options) {
     throw new Error('The state mixin is expecting some options');
@@ -19,12 +19,12 @@ function StateMixin(options) {
     instanceMethods = _.omit(options, reservedKeys);
   }
 
-  var mixin = _.extend({
+  let mixin = _.extend({
     contextTypes: {
       marty: React.PropTypes.object
     },
     componentDidMount: function () {
-      var component = {
+      let component = {
         id: this.__id,
         displayName: this.displayName || this.constructor.displayName,
       };
@@ -41,7 +41,7 @@ function StateMixin(options) {
       this.setState(this.getState());
     },
     componentWillUnmount: function () {
-      var instance = Instances.get(this);
+      let instance = Instances.get(this);
 
       if (instance) {
         if (instance.observer) {
@@ -52,10 +52,10 @@ function StateMixin(options) {
       }
     },
     componentWillReceiveProps: function (nextProps) {
-      var oldProps = this.props;
+      let oldProps = this.props;
       this.props = nextProps;
 
-      var newState = this.getState();
+      let newState = this.getState();
 
       this.props = oldProps;
       this.setState(newState);
@@ -64,7 +64,7 @@ function StateMixin(options) {
       return config.getState(this);
     },
     getInitialState: function () {
-      var el = this._currentElement;
+      let el = this._currentElement;
 
       if (!this.displayName && el && el.type) {
         this.displayName = el.type.displayName;
@@ -95,8 +95,8 @@ function StateMixin(options) {
   }
 
   function simpleMixinConfig(options) {
-    var stores = (options.listenTo || []);
-    var storesToGetStateFrom = findStoresToGetStateFrom(options);
+    let stores = (options.listenTo || []);
+    let storesToGetStateFrom = findStoresToGetStateFrom(options);
 
     if (!_.isArray(stores)) {
       stores = [stores];
@@ -114,7 +114,7 @@ function StateMixin(options) {
     };
 
     function getState(view) {
-      var state = _.object(_.map(storesToGetStateFrom, getStateFromStore));
+      let state = _.object(_.map(storesToGetStateFrom, getStateFromStore));
 
       if (options.getState) {
         state = _.extend(state, options.getState.call(view));
@@ -128,7 +128,7 @@ function StateMixin(options) {
     }
 
     function findStoresToGetStateFrom(options) {
-      var storesToGetStateFrom = {};
+      let storesToGetStateFrom = {};
       _.each(options, function (value, key) {
         if (reservedKeys.indexOf(key) === -1 && isStore(value)) {
           storesToGetStateFrom[key] = value;
@@ -140,7 +140,7 @@ function StateMixin(options) {
   }
 
   function areStores(stores) {
-    for (var i = stores.length - 1; i >= 0; i--) {
+    for (let i = stores.length - 1; i >= 0; i--) {
       if (!isStore(stores[i])) {
         return false;
       }

--- a/lib/stateSource/createStateSourceClass.js
+++ b/lib/stateSource/createStateSourceClass.js
@@ -1,17 +1,17 @@
-var _ = require('../utils/mindash');
-var StateSource = require('./stateSource');
-var createClass = require('../createClass');
-var HttpStateSource = require('./inbuilt/http');
-var CookieStateSource = require('./inbuilt/cookie');
-var LocationStateSource = require('./inbuilt/location');
-var JSONStorageStateSource = require('./inbuilt/jsonStorage');
-var LocalStorageStateSource = require('./inbuilt/localStorage');
-var SessionStorageStateSource = require('./inbuilt/sessionStorage');
+let _ = require('../utils/mindash');
+let StateSource = require('./stateSource');
+let createClass = require('../createClass');
+let HttpStateSource = require('./inbuilt/http');
+let CookieStateSource = require('./inbuilt/cookie');
+let LocationStateSource = require('./inbuilt/location');
+let JSONStorageStateSource = require('./inbuilt/jsonStorage');
+let LocalStorageStateSource = require('./inbuilt/localStorage');
+let SessionStorageStateSource = require('./inbuilt/sessionStorage');
 
 function createStateSourceClass(properties) {
   properties = properties || {};
 
-  var merge = [{}, properties].concat(properties.mixins || []);
+  let merge = [{}, properties].concat(properties.mixins || []);
 
   properties = _.extend.apply(_, merge);
 

--- a/lib/stateSource/inbuilt/cookie.js
+++ b/lib/stateSource/inbuilt/cookie.js
@@ -1,5 +1,5 @@
-var cookieFactory = defaultCookieFactory;
-var StateSource = require('../stateSource');
+let cookieFactory = defaultCookieFactory;
+let StateSource = require('../stateSource');
 
 class CookieStateSource extends StateSource {
   constructor(options) {

--- a/lib/stateSource/inbuilt/http/hooks/parseJSON.js
+++ b/lib/stateSource/inbuilt/http/hooks/parseJSON.js
@@ -1,6 +1,6 @@
-var CONTENT_TYPE = 'Content-Type';
-var JSON_CONTENT_TYPE = 'application/json';
-var _ = require('../../../../utils/mindash');
+let CONTENT_TYPE = 'Content-Type';
+let JSON_CONTENT_TYPE = 'application/json';
+let _ = require('../../../../utils/mindash');
 
 module.exports = {
   id: 'parseJSON',
@@ -18,7 +18,7 @@ module.exports = {
 };
 
 function isJson(res) {
-  var contentTypes = res.headers.get(CONTENT_TYPE);
+  let contentTypes = res.headers.get(CONTENT_TYPE);
 
   if (!_.isArray(contentTypes)) {
     if (contentTypes === undefined || contentTypes === null) {

--- a/lib/stateSource/inbuilt/http/hooks/stringifyJSON.js
+++ b/lib/stateSource/inbuilt/http/hooks/stringifyJSON.js
@@ -1,11 +1,11 @@
-var CONTENT_TYPE = 'Content-Type';
-var JSON_CONTENT_TYPE = 'application/json';
-var _ = require('../../../../utils/mindash');
+let CONTENT_TYPE = 'Content-Type';
+let JSON_CONTENT_TYPE = 'application/json';
+let _ = require('../../../../utils/mindash');
 
 module.exports = {
   id: 'stringifyJSON',
   before: function (req) {
-    var contentType = req.headers[CONTENT_TYPE] || JSON_CONTENT_TYPE;
+    let contentType = req.headers[CONTENT_TYPE] || JSON_CONTENT_TYPE;
 
     if (typeof FormData !== 'undefined' && req.body instanceof FormData) {
       return;

--- a/lib/stateSource/inbuilt/http/index.js
+++ b/lib/stateSource/inbuilt/http/index.js
@@ -1,10 +1,10 @@
 require('isomorphic-fetch');
 
-var hooks = {};
-var log = require('../../../logger');
-var _ = require('../../../utils/mindash');
-var StateSource = require('../../stateSource');
-var accepts = {
+let hooks = {};
+let log = require('../../../logger');
+let _ = require('../../../utils/mindash');
+let StateSource = require('../../stateSource');
+let accepts = {
   html: 'text/html',
   text: 'text/plain',
   json: 'application/json',
@@ -76,7 +76,7 @@ HttpStateSource.addHook(require('./hooks/includeCredentials'));
 module.exports = HttpStateSource;
 
 function requestOptions(method, source, options) {
-  var baseUrl = source.baseUrl || HttpStateSource.defaultBaseUrl;
+  let baseUrl = source.baseUrl || HttpStateSource.defaultBaseUrl;
 
   if (_.isString(options)) {
     options = _.extend({
@@ -91,9 +91,9 @@ function requestOptions(method, source, options) {
   options.method = method.toLowerCase();
 
   if (baseUrl) {
-    var separator = '';
-    var firstCharOfUrl = options.url[0];
-    var lastCharOfBaseUrl = baseUrl[baseUrl.length - 1];
+    let separator = '';
+    let firstCharOfUrl = options.url[0];
+    let lastCharOfBaseUrl = baseUrl[baseUrl.length - 1];
 
     // Do some text wrangling to make sure concatenation of base url
     // stupid people (i.e. me)
@@ -111,7 +111,7 @@ function requestOptions(method, source, options) {
   }
 
   if (options.dataType) {
-    var contentType = accepts[options.dataType];
+    let contentType = accepts[options.dataType];
 
     if (!contentType) {
       log.warn('Unknown data type ' + options.dataType);
@@ -135,10 +135,10 @@ function beforeRequest(source, req) {
 }
 
 function afterRequest(source, res) {
-  var current;
+  let current;
 
   _.each(getHooks('after'), (hook) => {
-    var execute = function (res) {
+    let execute = function (res) {
       try {
         return hook.after.call(source, res);
       } catch (e) {

--- a/lib/stateSource/inbuilt/jsonStorage.js
+++ b/lib/stateSource/inbuilt/jsonStorage.js
@@ -1,5 +1,5 @@
-var noopStorage = require('./noopStorage');
-var StateSource = require('../stateSource');
+let noopStorage = require('./noopStorage');
+let StateSource = require('../stateSource');
 
 class JSONStorageStateSource extends StateSource {
   constructor(options) {
@@ -12,14 +12,14 @@ class JSONStorageStateSource extends StateSource {
   }
 
   get(key) {
-    var raw = getStorage(this).getItem(getNamespacedKey(this, key));
+    let raw = getStorage(this).getItem(getNamespacedKey(this, key));
 
     if (!raw) {
       return raw;
     }
 
     try {
-      var payload = JSON.parse(raw);
+      let payload = JSON.parse(raw);
       return payload.value;
     } catch (e) {
       throw new Error('Unable to parse JSON from storage');
@@ -29,10 +29,10 @@ class JSONStorageStateSource extends StateSource {
   set(key, value) {
     // Wrap the value in an object so as to preserve it's type
     // during serialization.
-    var payload = {
+    let payload = {
       value: value
     };
-    var raw = JSON.stringify(payload);
+    let raw = JSON.stringify(payload);
     getStorage(this).setItem(getNamespacedKey(this, key), raw);
   }
 

--- a/lib/stateSource/inbuilt/localStorage.js
+++ b/lib/stateSource/inbuilt/localStorage.js
@@ -1,5 +1,5 @@
-var noopStorage = require('./noopStorage');
-var StateSource = require('../stateSource');
+let noopStorage = require('./noopStorage');
+let StateSource = require('../stateSource');
 
 class LocalStorageStateSource extends StateSource {
   constructor(options) {

--- a/lib/stateSource/inbuilt/location.js
+++ b/lib/stateSource/inbuilt/location.js
@@ -1,6 +1,6 @@
-var _ = require('../../utils/mindash');
-var StateSource = require('../stateSource');
-var locationFactory = defaultLocationFactory;
+let _ = require('../../utils/mindash');
+let StateSource = require('../stateSource');
+let locationFactory = defaultLocationFactory;
 
 class LocationStateSource extends StateSource {
   constructor(options) {
@@ -18,7 +18,7 @@ class LocationStateSource extends StateSource {
 }
 
 function defaultLocationFactory(context, location) {
-  var l = location || window.location;
+  let l = location || window.location;
 
   return {
     url: l.url,
@@ -29,10 +29,10 @@ function defaultLocationFactory(context, location) {
   };
 
   function query(search) {
-    var result = {};
+    let result = {};
 
     _.each(search.substr(1).split('&'), function (part) {
-      var item = part.split('=');
+      let item = part.split('=');
       result[item[0]] = decodeURIComponent(item[1]);
     });
 

--- a/lib/stateSource/inbuilt/noopStorage.js
+++ b/lib/stateSource/inbuilt/noopStorage.js
@@ -1,4 +1,4 @@
-var _ = require('../../utils/mindash');
+let _ = require('../../utils/mindash');
 
 module.exports = {
   getItem: _.noop,

--- a/lib/stateSource/inbuilt/sessionStorage.js
+++ b/lib/stateSource/inbuilt/sessionStorage.js
@@ -1,5 +1,5 @@
-var noopStorage = require('./noopStorage');
-var StateSource = require('../stateSource');
+let noopStorage = require('./noopStorage');
+let StateSource = require('../stateSource');
 
 class SessionStorageStateSource extends StateSource {
   constructor(options) {

--- a/lib/stateSource/stateSource.js
+++ b/lib/stateSource/stateSource.js
@@ -1,9 +1,9 @@
-var log = require('../logger');
-var uuid = require('../utils/uuid');
-var warnings = require('../warnings');
-var Instances = require('../instances');
-var resolve = require('../utils/resolve');
-var Environment = require('../environment');
+let log = require('../logger');
+let uuid = require('../utils/uuid');
+let warnings = require('../warnings');
+let Instances = require('../instances');
+let resolve = require('../utils/resolve');
+let Environment = require('../environment');
 
 class StateSource {
   constructor(options) {

--- a/lib/store/createStoreClass.js
+++ b/lib/store/createStoreClass.js
@@ -1,28 +1,28 @@
-var log = require('../logger');
-var Store = require('./store');
-var _ = require('../utils/mindash');
-var warnings = require('../warnings');
-var createClass = require('../createClass');
+let log = require('../logger');
+let Store = require('./store');
+let _ = require('../utils/mindash');
+let warnings = require('../warnings');
+let createClass = require('../createClass');
 
-var RESERVED_FUNCTIONS = ['getState'];
-var VIRTUAL_FUNCTIONS = ['clear', 'dispose'];
+let RESERVED_FUNCTIONS = ['getState'];
+let VIRTUAL_FUNCTIONS = ['clear', 'dispose'];
 
 function createStoreClass(properties) {
   validateStoreOptions(properties);
   addMixins(properties);
 
-  var overrideFunctions = getOverrideFunctions(properties);
-  var functionsToOmit = _.union(VIRTUAL_FUNCTIONS, RESERVED_FUNCTIONS);
-  var classProperties = _.extend(_.omit(properties, functionsToOmit), overrideFunctions);
+  let overrideFunctions = getOverrideFunctions(properties);
+  let functionsToOmit = _.union(VIRTUAL_FUNCTIONS, RESERVED_FUNCTIONS);
+  let classProperties = _.extend(_.omit(properties, functionsToOmit), overrideFunctions);
 
   return createClass(classProperties, classProperties, Store);
 }
 
 function getOverrideFunctions(properties) {
-  var overrideFunctions = _.pick(properties, VIRTUAL_FUNCTIONS);
+  let overrideFunctions = _.pick(properties, VIRTUAL_FUNCTIONS);
 
   _.each(_.functions(overrideFunctions), function (name) {
-    var override = overrideFunctions[name];
+    let override = overrideFunctions[name];
 
     overrideFunctions[name] = function () {
       Store.prototype[name].call(this);
@@ -34,11 +34,11 @@ function getOverrideFunctions(properties) {
 }
 
 function addMixins(properties) {
-  var handlers = _.map(properties.mixins, function (mixin) {
+  let handlers = _.map(properties.mixins, function (mixin) {
     return mixin.handlers;
   });
 
-  var mixins = _.map(properties.mixins, function (mixin) {
+  let mixins = _.map(properties.mixins, function (mixin) {
     return _.omit(mixin, 'handlers');
   });
 
@@ -47,7 +47,7 @@ function addMixins(properties) {
 }
 
 function validateStoreOptions(properties) {
-  var displayName = properties.displayName;
+  let displayName = properties.displayName;
 
   _.each(RESERVED_FUNCTIONS, function (functionName) {
     if (properties[functionName]) {

--- a/lib/store/fetch.js
+++ b/lib/store/fetch.js
@@ -1,17 +1,17 @@
-var log = require('../logger');
-var _ = require('../utils/mindash');
-var warnings = require('../warnings');
-var Instances = require('../instances');
-var fetchResult = require('./fetchResult');
-var StoreEvents = require('./storeEvents');
-var CompoundError = require('../errors/compound');
-var NotFoundError = require('../errors/notFound');
-var StoreConstants = require('../constants/store');
-var StatusConstants = require('../constants/status');
+let log = require('../logger');
+let _ = require('../utils/mindash');
+let warnings = require('../warnings');
+let Instances = require('../instances');
+let fetchResult = require('./fetchResult');
+let StoreEvents = require('./storeEvents');
+let CompoundError = require('../errors/compound');
+let NotFoundError = require('../errors/notFound');
+let StoreConstants = require('../constants/store');
+let StatusConstants = require('../constants/status');
 
 function fetch(id, local, remote) {
-  var store = this, instance = Instances.get(this);
-  var options, result, error, cacheError, context = this.context;
+  let store = this, instance = Instances.get(this);
+  let options, result, error, cacheError, context = this.context;
 
   if (_.isObject(id)) {
     options = id;
@@ -60,7 +60,7 @@ function fetch(id, local, remote) {
 
   function tryAndGetLocally(remoteCalled) {
     try {
-      var result = options.locally.call(store);
+      let result = options.locally.call(store);
 
       if (_.isUndefined(result)) {
         return;
@@ -135,7 +135,7 @@ function fetch(id, local, remote) {
   }
 
   function promiseNotReturnedWarning() {
-    var inStore = '';
+    let inStore = '';
     if (store.displayName) {
       inStore = ' in ' + store.displayName;
     }
@@ -195,9 +195,9 @@ function fetch(id, local, remote) {
 }
 
 function dependencyResult(store, options) {
-  var pending = false;
-  var errors = [];
-  var dependencies = options.dependsOn;
+  let pending = false;
+  let errors = [];
+  let dependencies = options.dependsOn;
 
   if (!dependencies) {
     return;
@@ -219,7 +219,7 @@ function dependencyResult(store, options) {
   });
 
   if (errors.length) {
-    var error = errors.length === 1 ? errors[0] : new CompoundError(errors);
+    let error = errors.length === 1 ? errors[0] : new CompoundError(errors);
 
     return fetchResult.failed(error, options.id, store);
   }

--- a/lib/store/fetchResult.js
+++ b/lib/store/fetchResult.js
@@ -1,5 +1,5 @@
-var when = require('./when');
-var NotFoundError = require('../errors/notFound');
+let when = require('./when');
+let NotFoundError = require('../errors/notFound');
 
 module.exports = {
   done: done,
@@ -51,7 +51,7 @@ function fetchResult(initialResult, store) {
 
   function toPromise() {
     return new Promise(function (resolve, reject) {
-      var listener;
+      let listener;
 
       if (!tryResolveFetch(initialResult)) {
         listener = store.addFetchChangedListener(tryResolveFetch);

--- a/lib/store/handleAction.js
+++ b/lib/store/handleAction.js
@@ -1,16 +1,16 @@
-var _ = require('../utils/mindash');
-var Instances = require('../instances');
+let _ = require('../utils/mindash');
+let Instances = require('../instances');
 
 function handleAction(action) {
   Instances.get(this).validateHandlers();
 
-  var store = this;
-  var handlers = _.object(_.map(store.handlers, getHandlerWithPredicates));
+  let store = this;
+  let handlers = _.object(_.map(store.handlers, getHandlerWithPredicates));
 
   _.each(handlers, function (predicates, handlerName) {
     _.each(predicates, function (predicate) {
       if (predicate(action)) {
-        var rollbackHandler;
+        let rollbackHandler;
 
         try {
           store.action = action;
@@ -27,7 +27,7 @@ function handleAction(action) {
 function getHandlerWithPredicates(actionPredicates, handler) {
   _.isArray(actionPredicates) || (actionPredicates = [actionPredicates]);
 
-  var predicates = _.map(actionPredicates, toFunc);
+  let predicates = _.map(actionPredicates, toFunc);
 
   return [handler, predicates];
 
@@ -42,7 +42,7 @@ function getHandlerWithPredicates(actionPredicates, handler) {
       };
     }
 
-    var func = _.matches(actionPredicate);
+    let func = _.matches(actionPredicate);
 
     func.toJSON = function () {
       return actionPredicate;

--- a/lib/store/store.js
+++ b/lib/store/store.js
@@ -1,17 +1,17 @@
-var log = require('../logger');
-var fetch = require('./fetch');
-var _ = require('../utils/mindash');
-var uuid = require('../utils/uuid');
-var warnings = require('../warnings');
-var Instances = require('../instances');
-var resolve = require('../utils/resolve');
-var StoreEvents = require('./storeEvents');
-var Environment = require('../environment');
-var handleAction = require('./handleAction');
-var EventEmitter = require('events').EventEmitter;
-var validateHandlers = require('./validateHandlers');
+let log = require('../logger');
+let fetch = require('./fetch');
+let _ = require('../utils/mindash');
+let uuid = require('../utils/uuid');
+let warnings = require('../warnings');
+let Instances = require('../instances');
+let resolve = require('../utils/resolve');
+let StoreEvents = require('./storeEvents');
+let Environment = require('../environment');
+let handleAction = require('./handleAction');
+let EventEmitter = require('events').EventEmitter;
+let validateHandlers = require('./validateHandlers');
 
-var DEFAULT_MAX_LISTENERS = 1000000;
+let DEFAULT_MAX_LISTENERS = 1000000;
 
 class Store {
   constructor(options) {
@@ -22,7 +22,7 @@ class Store {
     this.__type = 'Store';
     this.__id = uuid.type(this.__type);
 
-    var instance = Instances.add(this, _.extend({
+    let instance = Instances.add(this, _.extend({
       state: {},
       fetchHistory: {},
       failedFetches: {},
@@ -31,9 +31,9 @@ class Store {
       validateHandlers: _.once(() => validateHandlers(this))
     }, options));
 
-    var emitter = instance.emitter;
-    var dispatcher = instance.dispatcher;
-    var initialState = this.getInitialState();
+    let emitter = instance.emitter;
+    let dispatcher = instance.dispatcher;
+    let initialState = this.getInitialState();
 
     emitter.setMaxListeners(DEFAULT_MAX_LISTENERS);
 
@@ -73,19 +73,19 @@ class Store {
   }
 
   setState(state) {
-    var newState = _.extend({}, this.state, state);
+    let newState = _.extend({}, this.state, state);
 
     this.replaceState(newState);
   }
 
   replaceState(newState) {
-    var instance = getInstance(this);
-    var currentState = instance.state;
+    let instance = getInstance(this);
+    let currentState = instance.state;
 
 
     if (_.isUndefined(newState) || _.isNull(newState)) {
       if (warnings.stateIsNullOrUndefined) {
-        var displayName = this.displayName || this.id;
+        let displayName = this.displayName || this.id;
 
         log.warn(
           `Warning: Trying to replace the state of the store ${displayName} with null or undefined`
@@ -100,7 +100,7 @@ class Store {
   }
 
   clear(newState) {
-    var instance = getInstance(this);
+    let instance = getInstance(this);
     instance.fetchHistory = {};
     instance.failedFetches = {};
     instance.fetchInProgress = {};
@@ -113,9 +113,9 @@ class Store {
   }
 
   dispose() {
-    var instance = getInstance(this);
-    var emitter = instance.emitter;
-    var dispatchToken = this.dispatchToken;
+    let instance = getInstance(this);
+    let emitter = instance.emitter;
+    let dispatchToken = this.dispatchToken;
 
     emitter.removeAllListeners(StoreEvents.CHANGE_EVENT);
     emitter.removeAllListeners(StoreEvents.FETCH_CHANGE_EVENT);
@@ -130,11 +130,11 @@ class Store {
   }
 
   hasChanged(eventArgs) {
-    var emitChange = () => {
-      var instance = getInstance(this);
+    let emitChange = () => {
+      let instance = getInstance(this);
 
       if (instance) {
-        var emitter = instance.emitter;
+        let emitter = instance.emitter;
 
         emitter.emit.call(emitter, StoreEvents.CHANGE_EVENT, this.state, this, eventArgs);
       }
@@ -155,7 +155,7 @@ class Store {
   }
 
   addChangeListener(callback, context) {
-    var emitter = getInstance(this).emitter;
+    let emitter = getInstance(this).emitter;
 
     if (context) {
       callback = _.bind(callback, context);
@@ -179,7 +179,7 @@ class Store {
   }
 
   addFetchChangedListener(callback, context) {
-    var emitter = getInstance(this).emitter;
+    let emitter = getInstance(this).emitter;
 
     if (context) {
       callback = _.bind(callback, context);
@@ -195,7 +195,7 @@ class Store {
   }
 
   waitFor(stores) {
-    var dispatcher = getInstance(this).dispatcher;
+    let dispatcher = getInstance(this).dispatcher;
 
     if (!_.isArray(stores)) {
       stores = _.toArray(arguments);
@@ -204,7 +204,7 @@ class Store {
     dispatcher.waitFor(dispatchTokens(stores));
 
     function dispatchTokens(stores) {
-      var tokens = [];
+      let tokens = [];
 
       _.each(stores, function (store) {
         if (store.dispatchToken) {

--- a/lib/store/validateHandlers.js
+++ b/lib/store/validateHandlers.js
@@ -1,10 +1,10 @@
-var _ = require('../utils/mindash');
-var ActionHandlerNotFoundError = require('../errors/actionHandlerNotFound');
-var ActionPredicateUndefinedError = require('../errors/actionPredicateUndefined');
+let _ = require('../utils/mindash');
+let ActionHandlerNotFoundError = require('../errors/actionHandlerNotFound');
+let ActionPredicateUndefinedError = require('../errors/actionPredicateUndefined');
 
 function validateHandlers(store) {
   _.each(store.handlers, function (actionPredicate, handlerName) {
-    var actionHandler = store[handlerName];
+    let actionHandler = store[handlerName];
 
     if (_.isUndefined(actionHandler) || _.isNull(actionHandler)) {
       throw new ActionHandlerNotFoundError(handlerName, store);

--- a/lib/store/when.js
+++ b/lib/store/when.js
@@ -1,6 +1,6 @@
-var log = require('../logger');
-var _ = require('../utils/mindash');
-var StatusConstants = require('../constants/status');
+let log = require('../logger');
+let _ = require('../utils/mindash');
+let StatusConstants = require('../constants/status');
 
 when.all = all;
 when.join = join;
@@ -8,7 +8,7 @@ when.join = join;
 function when(handlers, parentContext) {
   handlers || (handlers = {});
 
-  var handler = handlers[this.status.toLowerCase()];
+  let handler = handlers[this.status.toLowerCase()];
 
   if (!handler) {
     throw new Error('Could not find a ' + this.status + ' handler');
@@ -30,7 +30,7 @@ function when(handlers, parentContext) {
         throw new Error('Unknown fetch result status');
     }
   } catch (e) {
-    var errorMessage = 'An error occured when handling the DONE state of ';
+    let errorMessage = 'An error occured when handling the DONE state of ';
 
     if (this.id) {
       errorMessage += 'the fetch \'' + this.id + '\'';
@@ -53,9 +53,9 @@ function when(handlers, parentContext) {
 }
 
 function join(/* fetchResults, handlers */) {
-  var parentContext;
-  var handlers = _.last(arguments);
-  var fetchResults = _.initial(arguments);
+  let parentContext;
+  let handlers = _.last(arguments);
+  let fetchResults = _.initial(arguments);
 
   if (!areHandlers(handlers) && areHandlers(_.last(fetchResults))) {
     parentContext = handlers;
@@ -74,7 +74,7 @@ function all(fetchResults, handlers, parentContext) {
     throw new Error('Must specify a set of fetch results');
   }
 
-  var context = {
+  let context = {
     result: results(fetchResults),
     error: firstError(fetchResults),
     status: aggregateStatus(fetchResults)
@@ -94,7 +94,7 @@ function results(fetchResults) {
 }
 
 function firstError(fetchResults) {
-  var failedResult = _.find(fetchResults, {
+  let failedResult = _.find(fetchResults, {
     status: StatusConstants.FAILED.toString()
   });
 
@@ -108,8 +108,8 @@ function notFetchResult(result) {
 }
 
 function aggregateStatus(fetchResults) {
-  for (var i = fetchResults.length - 1; i >= 0; i--) {
-    var status = fetchResults[i].status;
+  for (let i = fetchResults.length - 1; i >= 0; i--) {
+    let status = fetchResults[i].status;
 
     if (status === StatusConstants.FAILED.toString() ||
         status === StatusConstants.PENDING.toString()) {

--- a/lib/storeObserver.js
+++ b/lib/storeObserver.js
@@ -1,5 +1,5 @@
-var log = require('./logger');
-var _ = require('./utils/mindash');
+let log = require('./logger');
+let _ = require('./utils/mindash');
 
 class StoreObserver {
   constructor(options) {
@@ -18,15 +18,15 @@ class StoreObserver {
   }
 
   listenToStore(store) {
-    var component = this.component;
-    var storeDisplayName = store.displayName || store.id;
+    let component = this.component;
+    let storeDisplayName = store.displayName || store.id;
 
     log.trace(
       `The ${component.displayName} component  (${component.id}) is listening to the ${storeDisplayName} store`
     );
 
     return store.for(component).addChangeListener((state, store) => {
-      var storeDisplayName = store.displayName || store.id;
+      let storeDisplayName = store.displayName || store.id;
 
       log.trace(
         `${storeDisplayName} store has changed. ` +

--- a/lib/utils/classId.js
+++ b/lib/utils/classId.js
@@ -1,20 +1,20 @@
-var uuid = require('./uuid');
-var log = require('../logger');
-var warnings = require('../warnings');
-var humanStrings = require('./humanStrings');
+let uuid = require('./uuid');
+let log = require('../logger');
+let warnings = require('../warnings');
+let humanStrings = require('./humanStrings');
 
 function classId(clazz, type) {
   if (clazz.id) {
     return clazz.id;
   }
 
-  var displayName = '';
+  let displayName = '';
 
   if (clazz.displayName) {
     displayName = `'${clazz.displayName}' `;
   }
 
-  var typeDisplayName = humanStrings[type] || type;
+  let typeDisplayName = humanStrings[type] || type;
 
   if (warnings.classDoesNotHaveAnId) {
     log.warn(`Warning: The ${typeDisplayName} ${displayName}does not have an Id`);

--- a/lib/utils/compositeDisposable.js
+++ b/lib/utils/compositeDisposable.js
@@ -1,7 +1,7 @@
-var _ = require('./mindash');
+let _ = require('./mindash');
 
 function CompositeDisposable() {
-  var disposables = _.toArray(arguments);
+  let disposables = _.toArray(arguments);
 
   this.add = add;
   this.dispose = dispose;

--- a/lib/utils/deferred.js
+++ b/lib/utils/deferred.js
@@ -1,5 +1,5 @@
 function deferred() {
-  var result = {};
+  let result = {};
   result.promise = new Promise(function (resolve, reject) {
     result.resolve = resolve;
     result.reject = reject;

--- a/lib/utils/getContext.js
+++ b/lib/utils/getContext.js
@@ -1,4 +1,4 @@
-var Context = require('../context');
+let Context = require('../context');
 
 function getContext(obj) {
   if (!obj) {

--- a/lib/utils/resolve.js
+++ b/lib/utils/resolve.js
@@ -1,9 +1,9 @@
-var log = require('../logger');
-var warnings = require('../warnings');
-var getContext = require('./getContext');
+let log = require('../logger');
+let warnings = require('../warnings');
+let getContext = require('./getContext');
 
 function resolve(obj, subject) {
-  var context = getContext(subject);
+  let context = getContext(subject);
 
   if (context) {
     return context.resolve(obj);

--- a/lib/utils/serializeError.js
+++ b/lib/utils/serializeError.js
@@ -3,7 +3,7 @@ function serializeError(error) {
     return null;
   }
 
-  var result = {
+  let result = {
     name: error.name
   };
 

--- a/lib/warnings.js
+++ b/lib/warnings.js
@@ -1,6 +1,6 @@
-var _ = require('./utils/mindash');
+let _ = require('./utils/mindash');
 
-var warnings = {
+let warnings = {
   without: without,
   invokeConstant: true,
   reservedFunction: true,

--- a/marty.js
+++ b/marty.js
@@ -1,18 +1,18 @@
 require('es6-promise').polyfill();
 
-var state = require('./lib/state');
-var create = require('./lib/create');
-var logger = require('./lib/logger');
-var _ = require('./lib/utils/mindash');
-var dispose = require('./lib/dispose');
-var classes = require('./lib/classes');
-var warnings = require('./lib/warnings');
-var Registry = require('./lib/registry');
-var Dispatcher = require('./lib/dispatcher');
-var Diagnostics = require('./lib/diagnostics');
-var environment = require('./lib/environment');
-var EventEmitter = require('events').EventEmitter;
-var renderToString = require('./lib/renderToString');
+let state = require('./lib/state');
+let create = require('./lib/create');
+let logger = require('./lib/logger');
+let _ = require('./lib/utils/mindash');
+let dispose = require('./lib/dispose');
+let classes = require('./lib/classes');
+let warnings = require('./lib/warnings');
+let Registry = require('./lib/registry');
+let Dispatcher = require('./lib/dispatcher');
+let Diagnostics = require('./lib/diagnostics');
+let environment = require('./lib/environment');
+let EventEmitter = require('events').EventEmitter;
+let renderToString = require('./lib/renderToString');
 
 function createInstance() {
   return _.extend({


### PR DESCRIPTION
As we're embracing ES6 more and more, I think that the first step would be to convert all of those `var`s to `let`s.

I don't know how far we can go with tests though, are the fixtures passed through babel as well? Otherwise we might hit [some incompatibility on older browsers](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#Browser_compatibility)... 

Another step forward would be to convert all the `require`s and `export`s to `import Module from 'module'` and `export default Module`, etc. I'm happy to go through it if you're ok with that?

Thoughts?