### PR TITLE
Stores API documentation fix (`UserAPI` -> `UserQueries`)

### DIFF
--- a/docs/_api/stores/index.md
+++ b/docs/_api/stores/index.md
@@ -445,7 +445,7 @@ var UsersStore = Marty.createStore({
         return this.state[id];
       },
       function () {
-        return UserAPI.getUser(id);
+        return UserQueries.getUser(id);
       }
     });
   }
@@ -457,7 +457,7 @@ class UsersStore extends Marty.Store {
   getUser(id) {
     return this.fetch(id,
       () => return this.state[id],
-      () => return UserAPI.getUser(id)
+      () => return UserQueries.getUser(id)
     );
   }
 });


### PR DESCRIPTION
I presume this is a hangover from the update to 0.9, and that the pattern I've used is the correct one. If I'm wrong let me know!