### PR TITLE
Make sure ES6 registerables have their ids

### DIFF
--- a/dist/node/lib/create.js
+++ b/dist/node/lib/create.js
@@ -7,7 +7,7 @@ var createStoreClass = require("./store/createStoreClass");
 var createQueriesClass = require("./queries/createQueriesClass");
 var createStateSourceClass = require("./stateSource/createStateSourceClass");
 var createActionCreatorsClass = require("./actionCreators/createActionCreatorsClass");
-var DEFAULT_CLASS_NAME = "Class";
+var getClassName = require("./utils/getClassName");
 
 module.exports = {
   register: register,
@@ -36,14 +36,6 @@ function register(clazz, id) {
 
 function createContext() {
   return this.registry.createContext();
-}
-
-function getClassName(clazz) {
-  var funcNameRegex = /function (.{1,})\(/;
-  var results = funcNameRegex.exec(clazz.toString());
-  var className = results && results.length > 1 ? results[1] : "";
-
-  return className === DEFAULT_CLASS_NAME ? null : className;
 }
 
 function createConstants(obj) {

--- a/dist/node/lib/registry.js
+++ b/dist/node/lib/registry.js
@@ -83,7 +83,8 @@ var Registry = (function () {
         }
 
         clazz.id = id;
-        clazz.type = type;
+        defaultInstance.id = defaultInstance.id || id;
+        defaultInstance.type = clazz.type = type;
 
         this.types[type][id] = clazz;
 

--- a/dist/node/lib/utils/getClassName.js
+++ b/dist/node/lib/utils/getClassName.js
@@ -1,0 +1,17 @@
+"use strict";
+
+var DEFAULT_CLASS_NAME = "Class";
+
+function getClassName(clazz) {
+  var className = clazz.name || clazz.constructor && clazz.constructor.name;
+
+  if (!className) {
+    var funcNameRegex = /function (.{1,})\(/;
+    var results = funcNameRegex.exec(clazz.toString());
+    className = results && results.length > 1 ? results[1] : "";
+  }
+
+  return className === DEFAULT_CLASS_NAME ? null : className;
+}
+
+module.exports = getClassName;

--- a/lib/create.js
+++ b/lib/create.js
@@ -5,7 +5,7 @@ var createStoreClass = require('./store/createStoreClass');
 var createQueriesClass = require('./queries/createQueriesClass');
 var createStateSourceClass = require('./stateSource/createStateSourceClass');
 var createActionCreatorsClass = require('./actionCreators/createActionCreatorsClass');
-var DEFAULT_CLASS_NAME = 'Class';
+var getClassName = require('./utils/getClassName');
 
 module.exports = {
   register: register,
@@ -35,14 +35,6 @@ function register(clazz, id) {
 
 function createContext() {
   return this.registry.createContext();
-}
-
-function getClassName(clazz) {
-  var funcNameRegex = /function (.{1,})\(/;
-  var results = (funcNameRegex).exec(clazz.toString());
-  var className = (results && results.length > 1) ? results[1] : '';
-
-  return className === DEFAULT_CLASS_NAME ? null : className;
 }
 
 function createConstants(obj) {

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -67,7 +67,8 @@ class Registry {
     }
 
     clazz.id = id;
-    clazz.type = type;
+    defaultInstance.id = defaultInstance.id || id;
+    defaultInstance.type = clazz.type = type;
 
     this.types[type][id] = clazz;
 

--- a/lib/utils/getClassName.js
+++ b/lib/utils/getClassName.js
@@ -1,0 +1,15 @@
+var DEFAULT_CLASS_NAME = 'Class';
+
+function getClassName(clazz) {
+  var className = clazz.name || (clazz.constructor && clazz.constructor.name);
+
+  if (!className) {
+    var funcNameRegex = /function (.{1,})\(/;
+    var results = (funcNameRegex).exec(clazz.toString());
+    className = (results && results.length > 1) ? results[1] : '';
+  }
+
+  return className === DEFAULT_CLASS_NAME ? null : className;
+}
+
+module.exports = getClassName;

--- a/test/browser/registerSpec.js
+++ b/test/browser/registerSpec.js
@@ -30,6 +30,10 @@ describe('Marty#register', function () {
       it('should default to the class name', function () {
         expect(Marty.registry.getDefault('Store', 'ExpectedStore')).to.equal(ActualStore);
       });
+
+      it('should default to the class name on the default instance', function () {
+        expect(Marty.registry.getDefault('Store', 'ExpectedStore').id).to.equal(ActualStore);
+      });
     });
 
     describe('when you pass in an id', function () {
@@ -48,8 +52,12 @@ describe('Marty#register', function () {
         expect(ActualStore.getFoo(123)).to.eql(expectedInitialState[123]);
       });
 
-      it('should default to the class name', function () {
-        expect(Marty.registry.getDefault('Store', expectedId)).to.equal(ActualStore);
+      it('should use the specified id', function () {
+        expect(Marty.registry.getDefault('Store', expectedId)).to.equal(expectedId);
+      });
+
+      it('should use the specified id on the default instance', function () {
+        expect(Marty.registry.getDefault('Store', expectedId).id).to.equal(expectedId);
       });
     });
 


### PR DESCRIPTION
Make sure ES6 registerables (like `Store`s, `StateSource`s and `ActionCreator`s) get their `id` to default to their class name.

[ref](https://gitter.im/jhollingworth/marty?at=5512b9e2a61b930e5dbca11a)
[manual test to showcase the issue](https://gist.github.com/dariocravero/c4442ad42412a43ec1ff)