### PR TITLE
Always ensure the Container's name is getting the InnerComponent's name

### DIFF
--- a/lib/create.js
+++ b/lib/create.js
@@ -5,7 +5,7 @@ var createStoreClass = require('./store/createStoreClass');
 var createQueriesClass = require('./queries/createQueriesClass');
 var createStateSourceClass = require('./stateSource/createStateSourceClass');
 var createActionCreatorsClass = require('./actionCreators/createActionCreatorsClass');
-var DEFAULT_CLASS_NAME = 'Class';
+var getClassName = require('./utils/getClassName');
 
 module.exports = {
   register: register,
@@ -35,14 +35,6 @@ function register(clazz, id) {
 
 function createContext() {
   return this.registry.createContext();
-}
-
-function getClassName(clazz) {
-  var funcNameRegex = /function (.{1,})\(/;
-  var results = (funcNameRegex).exec(clazz.toString());
-  var className = (results && results.length > 1) ? results[1] : '';
-
-  return className === DEFAULT_CLASS_NAME ? null : className;
 }
 
 function createConstants(obj) {

--- a/lib/createContainer/createContainer.js
+++ b/lib/createContainer/createContainer.js
@@ -4,6 +4,7 @@ var _ = require('../utils/mindash');
 var uuid = require('../utils/uuid');
 var StoreObserver = require('../storeObserver');
 var getFetchResult = require('./getFetchResult');
+var getClassName = require("../utils/getClassName");
 
 function createContainer(InnerComponent, config) {
   config = config || {};
@@ -14,6 +15,7 @@ function createContainer(InnerComponent, config) {
 
   var observer;
   var id = uuid.type('Component');
+  var innerComponentDisplayName = InnerComponent.displayName || getClassName(InnerComponent);
 
   var Container = React.createClass({
     contextTypes: {
@@ -22,7 +24,7 @@ function createContainer(InnerComponent, config) {
     componentDidMount() {
       var component = {
         id: id,
-        displayName: InnerComponent.displayName
+        displayName: innerComponentDisplayName
       };
 
       observer = new StoreObserver({
@@ -89,7 +91,7 @@ function createContainer(InnerComponent, config) {
   });
 
   Container.InnerComponent = InnerComponent;
-  Container.displayName = InnerComponent.displayName + 'Container';
+  Container.displayName = innerComponentDisplayName + 'Container';
 
   return Container;
 }

--- a/lib/createContainer/createContainer.js
+++ b/lib/createContainer/createContainer.js
@@ -4,7 +4,7 @@ var _ = require('../utils/mindash');
 var uuid = require('../utils/uuid');
 var StoreObserver = require('../storeObserver');
 var getFetchResult = require('./getFetchResult');
-var getClassName = require("../utils/getClassName");
+var getClassName = require('../utils/getClassName');
 
 function createContainer(InnerComponent, config) {
   config = config || {};

--- a/lib/utils/getClassName.js
+++ b/lib/utils/getClassName.js
@@ -1,0 +1,15 @@
+var DEFAULT_CLASS_NAME = 'Class';
+
+function getClassName(clazz) {
+  var className = clazz.name || (clazz.constructor && clazz.constructor.name);
+
+  if (!className) {
+    var funcNameRegex = /function (.{1,})\(/;
+    var results = (funcNameRegex).exec(clazz.toString());
+    className = (results && results.length > 1) ? results[1] : '';
+  }
+
+  return className === DEFAULT_CLASS_NAME ? null : className;
+}
+
+module.exports = getClassName;

--- a/test/browser/containerSpec.js
+++ b/test/browser/containerSpec.js
@@ -74,8 +74,19 @@ describe('Container', function () {
       expect(ContainerComponent.InnerComponent).to.equal(InnerComponent);
     });
 
-    it('should set the display name', function () {
+    it('should set the display name on classical React components', function () {
       expect(render(ContainerComponent).refs.subject.constructor.displayName).to.eql('InnerComponentContainer');
+    });
+
+    it('should set the display name on ES6 React components', function () {
+      class ES6InnerComponent extends React.Component {
+        render() {
+          return React.createElement('div');
+        }
+      }
+
+      let ContainerES6Component = Marty.createContainer(ES6InnerComponent);
+      expect(render(ContainerES6Component).refs.subject.constructor.displayName).to.eql('ES6InnerComponentContainer');
     });
   });
 


### PR DESCRIPTION
Always ensure the `Container`'s name is getting the `InnerComponent`'s name.

Classical React components will get `displayName` [set through the jsx transformer](https://facebook.github.io/react/docs/component-specs.html#displayname) ([babel does it as well](https://babeljs.io/docs/usage/jsx/)).

Modern React components don't seem to get that treatment and `displayName` remains unset unless you explicitly set it.

```js
class MyComponent extends React.Component {}

typeof MyComponent.displayName === 'undefined' // => true
```

My first guess is to use [the constructor's property `name`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/name), however [IE doesn't support it yet](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/name#Browser_compatibility), that's why I've extracted away `getClassName` and we're reusing it here to have a better guess.