### PR TITLE
Docs: All ES6 classes need to be registered with Marty before using

### DIFF
--- a/docs/_guides/action-creators/handling-errors.md
+++ b/docs/_guides/action-creators/handling-errors.md
@@ -35,4 +35,6 @@ class UserActionCreators extends Marty.ActionCreators {
       .catch((err) => this.dispatch(UserConstants.SAVE_USER_FAILED, user, err));
   }
 }
+
+export default Marty.register(UserActionCreators);
 {% endsample %}

--- a/docs/_guides/action-creators/index.md
+++ b/docs/_guides/action-creators/index.md
@@ -41,7 +41,9 @@ class UserActionCreators extends Marty.ActionCreators {
   }
 }
 
-UserActionCreators.updateEmail(123, "foo@bar.com");
+userActionCreators = Marty.register(UserActionCreators);
+
+userActionCreators.updateEmail(123, "foo@bar.com");
 
 Dispatcher.register(function (action) {
   console.log(action.type) // => "UPDATE_EMAIL"

--- a/docs/_guides/fetching-state/index.md
+++ b/docs/_guides/fetching-state/index.md
@@ -47,6 +47,8 @@ class UserStore extends Marty.Store {
   }
 }
 
+export default Marty.register(UserStore);
+
 {% endsample %}
 
 When you call fetch, Marty will first try calling the ``locally`` function. It the state is present in the store then it's returned and the fetch will finish executing. If the store can't find the state locally it should return ``undefined``. This causes the fetch function to invoke ``remotely``. Once ``remotely`` has finished executing then fetch will then re-execute the ``locally`` function with the expectation that the state is now in the store. If it isn't then the fetch will fail with a "Not found" error. If the ``remotely`` function needs to get the state asynchronously you can return a promise. The fetch function will wait for the promise to be resolved before re-executing ``locally``.
@@ -119,15 +121,19 @@ class UserAPI extends Marty.HttpStateSource {
   }
 }
 
+var userAPI = Marty.register(UserAPI);
+
 class UserQueries extends Marty.Queries {
   getUser(userId) {
     this.dispatch(UserConstants.RECEIVE_USER_STARTING, userId);
 
-    UserAPI.getUser(userId)
+    userAPI.getUser(userId)
       .then(res => this.dispatch(UserConstants.RECEIVE_USER, userId, res.body))
       .catch(err => this.dispatch(UserConstants.RECEIVE_USER_FAILED, userId, err));
   }
 }
+
+var userQueries = Marty.register(UserQueries);
 
 class UserStore extends Marty.Store {
   constructor(options) {
@@ -148,7 +154,7 @@ class UserStore extends Marty.Store {
         return this.state[userId];
       },
       remotely: function () {
-        return UserQueries.getUser(userId)
+        return userQueries.getUser(userId)
       }
     });
   }

--- a/docs/_guides/flux/index.md
+++ b/docs/_guides/flux/index.md
@@ -39,7 +39,9 @@ class UserActionCreators extends Marty.ActionCreators {
   }
 }
 
-UserActionCreators.updateUserEmail(122, "foo@bar.com");
+userActionCreators = Marty.register(UserActionCreators);
+
+userActionCreators.updateUserEmail(122, "foo@bar.com");
 {% endsample %}
 
 In the above scenario, ``UserConstants.UPDATE_USER_EMAIL`` creates an action creator which, when invoked, will create an action with type `UPDATE_USER_EMAIL`.
@@ -98,6 +100,8 @@ class UserStore extends Marty.Store {
     this.hasChanged();
   }
 }
+
+export default Marty.register(UserStore);
 {% endsample %}
 
 When your application starts, each store automatically starts listening to the dispatcher. When an action is dispatched, each store checks its [``handlers`` hash]({% url /api/stores/index.html#handlers %}) to see if the store has a handler for the actions type. If it does it will call that handler, passing in the actions data. The action handler then updates its internal state (all stored in ``this.state``).
@@ -161,22 +165,22 @@ class User extends React.Component {
   }
   updateEmail(e) {
     var email = e.target.value;
-    UserActionCreators.updateUserEmail(this.props.userId, email);
+    userActionCreators.updateUserEmail(this.props.userId, email);
   }
   getInitialState() {
     return {
-      user: UserStore.getUser(this.props.userId)
+      user: userStore.getUser(this.props.userId)
     };
   }
   componentDidMount() {
-    this.userStoreListener = UserStore.addChangeListener(this.onUserStoreChanged);
+    this.userStoreListener = userStore.addChangeListener(this.onUserStoreChanged);
   }
   componentWillUnmount(nextProps) {
     this.userStoreListener.dispose();
   }
   onUserStoreChanged() {
     this.setState({
-      user: UserStore.getUser(this.props.userId)
+      user: userStore.getUser(this.props.userId)
     });
   }
 }
@@ -225,7 +229,7 @@ class User extends React.Component {
   }
   updateEmail(e) {
     var email = e.target.value;
-    UserActionCreators.updateUserEmail(this.props.userId, email);
+    userActionCreators.updateUserEmail(this.props.userId, email);
   }
 }
 
@@ -233,7 +237,7 @@ module.exports = Marty.createContainer(User, {
   listenTo: UserStore,
   fetch: {
     user() {
-      return UserStore.getUser(this.props.userId)
+      return userStore.getUser(this.props.userId)
     }
   }
 });

--- a/docs/_guides/queries/index.md
+++ b/docs/_guides/queries/index.md
@@ -40,6 +40,8 @@ class UserQueries extends Marty.Queries {
     }).catch((err) => this.dispatch(UserConstants.RECEIVE_USER_FAILED, id, err));
   }
 }
+
+export default Marty.register(UserQueries);
 {% endsample %}
 
 ##Why have Queries at all?

--- a/docs/_guides/state-sources/index.md
+++ b/docs/_guides/state-sources/index.md
@@ -45,7 +45,9 @@ class UserAPI extends Marty.HttpStateSource {
   }
 }
 
-UserAPI.getUsers();
+var userAPI = Marty.register(UserAPI);
+
+userAPI.getUsers();
 {% endsample %}
 
 Marty comes with a number of state sources out of the box:

--- a/docs/_guides/stores/immutable-data-collections.md
+++ b/docs/_guides/stores/immutable-data-collections.md
@@ -51,4 +51,6 @@ class UsersStore extends Marty.Store {
     this.state = this.state.push(user);
   }
 }
+
+export default Marty.register(UsersStore);
 {% endsample %}

--- a/docs/_guides/stores/index.md
+++ b/docs/_guides/stores/index.md
@@ -49,7 +49,9 @@ class UsersStore extends Marty.Store {
   }
 }
 
-var listener = UsersStore.addChangeListener(function () {
+var usersStore = Marty.register(UsersStore);
+
+var listener = usersStore.addChangeListener(function () {
   console.log('Users store changed');
   listener.dispose();
 });
@@ -89,4 +91,6 @@ class UsersStore extends Marty.Store {
     }
   }
 }
+
+export default Marty.register(UsersStore);
 {% endsample %}


### PR DESCRIPTION
Current docs just attempt to use a ES6 classs directly (not an instance). This doesn't work. Instances need to be obtained by using Marty.register