### PR TITLE
:memo: Tiny fix for classic container example

### DIFF
--- a/docs/_guides/containers/index.md
+++ b/docs/_guides/containers/index.md
@@ -19,7 +19,7 @@ var User = React.createClass({
 module.exports = Marty.createContainer(User, {
   listenTo: UserStore,
   fetch: {
-    user() {
+    user: function() {
       return UserStore.for(this).getUser(this.props.id);
     }
   },


### PR DESCRIPTION
Just swapped the syntax to actually be classic.