### PR TITLE
Use Node distribution in webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "A Javascript library for state management in React applications",
   "main": "dist/node/marty.js",
   "browser": "marty.js",
+  "webpack": "dist/node/marty.js",
   "directories": {
     "doc": "./doc",
     "lib": "./lib"


### PR DESCRIPTION
webpack's default resolve order for the main file in `package.json` is `webpack` > `browser` > ... > `main`. This means that webpack users will try to include `./marty.js`, which then includes the ES6 sources rather than the built ones, which means I then need to run everything through a transpiler for my build again.

Fixes #226