### PR TITLE
Generate lifecycle methods at container creation

### DIFF
--- a/lib/createContainer/createContainer.js
+++ b/lib/createContainer/createContainer.js
@@ -9,6 +9,7 @@ var getClassName = require('../utils/getClassName');
 var RESERVED_FUNCTIONS = [
   'contextTypes',
   'componentDidMount',
+  'componentWillReceiveProps',
   'onStoreChanged',
   'componentWillUnmount',
   'getInitialState',
@@ -29,7 +30,7 @@ function createContainer(InnerComponent, config) {
     marty: React.PropTypes.object
   }, config.contextTypes);
 
-  var Container = React.createClass(_.extend({
+  var specification = _.extend({
     contextTypes: contextTypes,
     componentDidMount() {
       var component = {
@@ -42,33 +43,10 @@ function createContainer(InnerComponent, config) {
         onStoreChanged: this.onStoreChanged,
         stores: getStoresToListenTo(this.listenTo, component)
       });
-
-      if (_.isFunction(config.componentDidMount)) {
-        config.componentDidMount.call(this);
-      }
-    },
-    componentWillMount() {
-      if (_.isFunction(config.componentWillMount)) {
-        config.componentWillMount.call(this);
-      }
     },
     componentWillReceiveProps(props) {
       this.props = props;
       this.setState(this.getState(props));
-
-      if (_.isFunction(config.componentWillReceiveProps)) {
-        config.componentWillReceiveProps.call(this, props);
-      }
-    },
-    componentWillUpdate(nextProps, nextState) {
-      if (_.isFunction(config.componentWillUpdate)) {
-        config.componentWillUpdate.call(this, nextProps, nextState);
-      }
-    },
-    componentDidUpdate(prevProps, prevState) {
-      if (_.isFunction(config.componentDidUpdate)) {
-        config.componentDidUpdate.call(this, prevProps, prevState);
-      }
     },
     onStoreChanged() {
       this.setState(this.getState());
@@ -76,10 +54,6 @@ function createContainer(InnerComponent, config) {
     componentWillUnmount() {
       if (this.observer) {
         this.observer.dispose();
-      }
-
-      if (_.isFunction(config.componentWillUnmount)) {
-        config.componentWillUnmount.call(this);
       }
     },
     getInitialState() {
@@ -123,7 +97,21 @@ function createContainer(InnerComponent, config) {
         }
       });
     }
-  }, _.omit(config, RESERVED_FUNCTIONS)));
+  }, _.omit(config, RESERVED_FUNCTIONS));
+
+  // Include lifecycle methods if specified in config. We don't need to
+  // explicitly handle the ones that aren't in RESERVED_FUNCTIONS.
+  specification.componentDidMount = callBoth(
+    specification.componentDidMount, config.componentDidMount
+  );
+  specification.componentWillReceiveProps = callBothWithProps(
+    specification.componentWillReceiveProps, config.componentWillReceiveProps
+  );
+  specification.componentWillUnmount = callBoth(
+    specification.componentWillUnmount, config.componentWillUnmount
+  );
+
+  var Container = React.createClass(specification);
 
   Container.InnerComponent = InnerComponent;
   Container.displayName = innerComponentDisplayName + 'Container';
@@ -155,4 +143,26 @@ function getStoresToListenTo(stores, component) {
 
     return isStore;
   });
+}
+
+function callBoth(func1, func2) {
+  if (_.isFunction(func2)) {
+    return function () {
+      func1.call(this);
+      func2.call(this);
+    };
+  } else {
+    return func1;
+  }
+}
+
+function callBothWithProps(func1, func2) {
+  if (_.isFunction(func2)) {
+    return function (props) {
+      func1.call(this, props);
+      func2.call(this, props);
+    };
+  } else {
+    return func1;
+  }
 }


### PR DESCRIPTION
For #249 

This also fixes a bug with `componentWillReceiveProps` where the base implementation would be overwritten by the configured one. I didn't explicitly add a test for this, but the existing test fails with thew new code without the change to `RESERVED_FUNCTIONS`.