### PR TITLE
Do not setState in container unless component is mounted

### DIFF
--- a/lib/createContainer/createContainer.js
+++ b/lib/createContainer/createContainer.js
@@ -49,7 +49,9 @@ function createContainer(InnerComponent, config) {
       this.setState(this.getState(props));
     },
     onStoreChanged() {
-      this.setState(this.getState());
+      if (this.isMounted()) {
+        this.setState(this.getState());
+      }
     },
     componentWillUnmount() {
       if (this.observer) {


### PR DESCRIPTION
Just came across a scenario where a store update caused the container to try and call setState when it was no longer mounted. This PR ensures setState is not called from onStoreChanged unless the container is currently mounted.