### PR TITLE
Fixing incorrect API example in Isomorphic docs

### DIFF
--- a/docs/_guides/isomorphism/index.md
+++ b/docs/_guides/isomorphism/index.md
@@ -70,7 +70,7 @@ module.exports = Marty.createContainer(User, {
 
 // renderToString.js
 Marty.renderToString({
-    component: User,
+    type: User,
     props: { id: 123 },
     context: Marty.createContext()
 }).then(function (render) {


### PR DESCRIPTION
It looks like lib/renderToString.js expects `type` and `props` properties on the options object, not `component` and `props`