### PR TITLE
Work around not being able to set res.body

### DIFF
--- a/lib/stateSource/inbuilt/http/hooks/parseJSON.js
+++ b/lib/stateSource/inbuilt/http/hooks/parseJSON.js
@@ -7,7 +7,16 @@ module.exports = {
   after: function (res) {
     if (isJson(res)) {
       return res.json().then(function (body) {
-        res.body = body;
+        try {
+          res.body = body;
+        } catch (e) {
+          if (e instanceof TypeError) {
+            // Workaround for Chrome 43+ where Response.body is not settable.
+            Object.defineProperty(res, 'body', {value: body});
+          } else {
+            throw e;
+          }
+        }
 
         return res;
       });


### PR DESCRIPTION
For #268 

I don't know how to write a test for this. The current tests fail against Chrome 43, but pass with this patch.